### PR TITLE
modified tests to run scheduling on platforms not supporting execution

### DIFF
--- a/tests/amx/test_amx_instr.py
+++ b/tests/amx/test_amx_instr.py
@@ -274,7 +274,8 @@ def test_matmul_on_amx_by_hand_i8(compiler, sde64):
         matmul_algorithm_i8(), get_transform_memory_i8(), matmul_on_amx
     ], t)
 
-def test_matmul_on_amx_scheduled_i8(compiler, sde64):
+@pytest.fixture
+def matmul_i8():
     size1 = 256
     size2 = 256
 
@@ -348,6 +349,12 @@ def test_matmul_on_amx_scheduled_i8(compiler, sde64):
     print("Final scheduled algorithm:")
     print(amx)
 
+    return amx
+
+def test_gen_matmul_i8_amx(matmul_i8):
+    pass
+
+def test_matmul_on_amx_scheduled_i8(compiler, sde64, matmul_i8):
     t = AMXTestBuilder(compiler.basename)
     t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
@@ -376,7 +383,7 @@ def test_matmul_on_amx_scheduled_i8(compiler, sde64):
                 ''])
 
     _run_amx(compiler, sde64, [
-        matmul_algorithm_i8(), get_transform_memory_i8(), amx,
+        matmul_algorithm_i8(), get_transform_memory_i8(), matmul_i8,
     ], t)
 
 

--- a/tests/amx/test_amx_instr.py
+++ b/tests/amx/test_amx_instr.py
@@ -358,6 +358,10 @@ def test_matmul_on_amx_scheduled_i8(compiler, sde64, matmul_i8):
     t = AMXTestBuilder(compiler.basename)
     t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
+    # duplicate from the fixture above
+    size1 = 256
+    size2 = 256
+
     t.alloc_dram_2i8('x', size1, size2, 'i+j')
     t.alloc_dram_2i8('y_orig', size2, size1, 'j')  # before transform_memory
     t.alloc_dram_2i8('y', size2 // 4, 4 * size1, '0')  # after transform_memory

--- a/tests/golden/test_x86/test_gen_avx2_simple_math_scheduling.txt
+++ b/tests/golden/test_x86/test_gen_avx2_simple_math_scheduling.txt
@@ -1,0 +1,15 @@
+def simple_math_avx2_sched(n: size, x: R[n] @ DRAM, y: R[n] @ DRAM):
+    for io in par(0, n / 8):
+        xyy: R[8] @ AVX2
+        xVec: R[8] @ AVX2
+        mm256_loadu_ps(xVec[0:8], x[8 * io + 0:8 * io + 8])
+        yVec: R[8] @ AVX2
+        mm256_loadu_ps(yVec[0:8], y[8 * io + 0:8 * io + 8])
+        xy: R[8] @ AVX2
+        mm256_mul_ps(xy, xVec, yVec)
+        mm256_mul_ps(xyy, xy, yVec)
+        mm256_storeu_ps(x[8 * io + 0:8 * io + 8], xyy[0:8])
+    if n % 8 > 0:
+        for ii in par(0, n % 8):
+            x[ii + n / 8 *
+              8] = x[ii + n / 8 * 8] * y[ii + n / 8 * 8] * y[ii + n / 8 * 8]


### PR DESCRIPTION
This will eliminate upload conflicts for me running on my mac without access to AVX2, AVX512, or AMX.  I can at least catch scheduling errors this way and fix the tests without triggering failed CI tests.