### PR TITLE
Codegen cleanup

### DIFF
--- a/apps/x86/sgemm/alex_sgemm.cpp
+++ b/apps/x86/sgemm/alex_sgemm.cpp
@@ -99,7 +99,7 @@ static void sgemm_accumulate(
 template <int I_REG, int J_REG>
 void sgemm_micro_kernel_staged_M_N(const float *a, const float *b, float *c,
     long ldc, const long N, const long K) {
-  vec_type inner_c[I_REG][J_REG] = {0};
+  vec_type inner_c[I_REG][J_REG] = {{0}};
 
   const auto Nb = N - 16 * (J_REG - 1);
   short mask = (1 << Nb) - 1;

--- a/src/exo/LoopIR_compiler.py
+++ b/src/exo/LoopIR_compiler.py
@@ -392,7 +392,7 @@ def _compile_context_struct(configs, lib_name):
     if not configs:
         return 'void', []
 
-    ctxt_name = f'{lib_name}_context'
+    ctxt_name = f'{lib_name}_Context'
     ctxt_def = [f"typedef struct {ctxt_name} {{ ", f""]
 
     seen = set()

--- a/src/exo/LoopIR_compiler.py
+++ b/src/exo/LoopIR_compiler.py
@@ -272,16 +272,13 @@ def compile_to_strings(lib_name, proc_list):
     # Get transitive closure of call-graph
     orig_procs = [id(p) for p in proc_list]
 
-    # Determine name for library context struct
-    ctxt_name = f"{lib_name}_Context"
-
     def from_lines(x):
         return "\n".join(x)
 
     proc_list = list(sorted(find_all_subprocs(proc_list), key=lambda x: x.name))
 
     # Header contents
-    ctxt_def = _compile_context_struct(find_all_configs(proc_list), ctxt_name)
+    ctxt_name, ctxt_def = _compile_context_struct(find_all_configs(proc_list), lib_name)
     struct_defns = set()
     public_fwd_decls = []
 
@@ -391,8 +388,13 @@ def _compile_memories(mems):
     return memory_code
 
 
-def _compile_context_struct(configs, ctxt_name):
+def _compile_context_struct(configs, lib_name):
+    if not configs:
+        return 'void', []
+
+    ctxt_name = f'{lib_name}_context'
     ctxt_def = [f"typedef struct {ctxt_name} {{ ", f""]
+
     seen = set()
     for c in sorted(configs, key=lambda x: x.name()):
         name = c.name()
@@ -408,8 +410,9 @@ def _compile_context_struct(configs, ctxt_name):
             ctxt_def += [""]
         else:
             ctxt_def += [f"// config '{name}' not materialized", ""]
+
     ctxt_def += [f"}} {ctxt_name};"]
-    return ctxt_def
+    return ctxt_name, ctxt_def
 
 
 # --------------------------------------------------------------------------- #

--- a/src/exo/LoopIR_compiler.py
+++ b/src/exo/LoopIR_compiler.py
@@ -422,7 +422,10 @@ class Compiler:
         self.new_varname(Sym('ctxt'), None)
         arg_strs.append(f"{ctxt_name} *ctxt")
 
+        non_const = set(e.buffer for e in proc.eff.writes + proc.eff.reduces)
+
         for a in proc.args:
+            const_kwd = 'const ' if a.name not in non_const else ''
             mem = a.mem if a.type.is_numeric() else None
             name_arg = self.new_varname(a.name, typ=a.type, mem=mem)
             if a.type in (T.size, T.index, T.bool, T.stride):
@@ -439,7 +442,7 @@ class Compiler:
                     arg_strs.append(f"struct {wintyp} {name_arg}")
                 else:
                     ctyp = a.type.basetype().ctype()
-                    arg_strs.append(f"{ctyp}* {name_arg}")
+                    arg_strs.append(f"{const_kwd}{ctyp}* {name_arg}")
                 mem = f" @{a.mem.name()}" if a.mem else ""
                 comment_str = f"{name_arg} : {a.type} {mem}"
                 typ_comments.append(comment_str)

--- a/tests/amx/test_amx_instr.py
+++ b/tests/amx/test_amx_instr.py
@@ -29,13 +29,12 @@ def test_ldst_i8_16x64(compiler, sde64):
         st_i8(16, 64, tile1, z)
 
     t = AMXTestBuilder(compiler.basename)
-    t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
     t.alloc_dram_2i8('x', 16, 64, 'i+j')
     t.alloc_dram_2i8('y', 16, 64, '0')
     t.alloc_dram_2i8('z', 16, 64, '0')
 
-    t.add_body(['ldst_i8_16x64(ctxt, x, y, z);',
+    t.add_body(['ldst_i8_16x64(NULL, x, y, z);',
                 '',
                 'if(check_eq_2i8(16, 64, x, z)) {',
                 '    printf("Correct\\n");',
@@ -66,14 +65,13 @@ def test_dpbssd_i8_16x64(compiler, sde64):
         st_i32(16, 16, tile2, z)
 
     t = AMXTestBuilder(compiler.basename)
-    t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
     t.alloc_dram_2i8('x', 16, 64, '1')
     t.alloc_dram_2i8('y', 16, 64, '1')
     t.alloc_dram_2i32('z', 16, 16, '64')  # expected result
     t.alloc_dram_2i32('res', 16, 16, '0')
 
-    t.add_body(['dpbssd_i8_16x64(ctxt, x, y, res);',
+    t.add_body(['dpbssd_i8_16x64(NULL, x, y, res);',
                 '',
                 'if(check_eq_2i32(16, 16, z, res)) {',
                 '    printf("Correct\\n");',
@@ -104,12 +102,11 @@ def test_transform_memory(compiler, sde64):
                     dest[i, 4 * j + k] = src[4 * i + k, j]
 
     t = AMXTestBuilder(compiler.basename)
-    t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
     t.alloc_dram_2i8('src', 64, 16, '5')
     t.alloc_dram_2i8('ans', 16, 64, '5')
     t.alloc_dram_2i8('res', 16, 64, '0')
-    t.add_body(['call_transform_memory(ctxt, 16, 16, src, res);',
+    t.add_body(['call_transform_memory(NULL, 16, 16, src, res);',
                 '',
                 'if(check_eq_2i8(16, 64, ans, res)) {',
                 '    printf("Correct\\n");',
@@ -248,7 +245,6 @@ def test_matmul_on_amx_by_hand_i8(compiler, sde64):
     size2 = 256
 
     t = AMXTestBuilder(compiler.basename)
-    t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
     t.alloc_dram_2i8('x', size1, size2, 'i+j')
     t.alloc_dram_2i8('y_orig', size2, size1, 'j+1')  # before transform_memory
@@ -256,11 +252,11 @@ def test_matmul_on_amx_by_hand_i8(compiler, sde64):
     t.alloc_dram_2i32('z', size1, size1, '0')  # expected result
     t.alloc_dram_2i32('res', size1, size1, '0')
 
-    t.add_body([f'transform_memory(ctxt, {size2}, {size1}, y_orig, y);'])
+    t.add_body([f'transform_memory(NULL, {size2}, {size1}, y_orig, y);'])
     t.add_body(
-        [f'matmul_on_cpu(ctxt, {size1}, {size2}, {size1}, x, y_orig, z);'])
+        [f'matmul_on_cpu(NULL, {size1}, {size2}, {size1}, x, y_orig, z);'])
     t.add_body(
-        [f'matmul_on_amx(ctxt, {size1}, {size2 // 4}, {size1}, x, y, res);'])
+        [f'matmul_on_amx(NULL, {size1}, {size2 // 4}, {size1}, x, y, res);'])
 
     t.add_body([f'if(check_eq_2i32({size1}, {size1}, z, res)) {{',
                 r'    printf("Correct\n");',
@@ -365,7 +361,6 @@ def test_gen_matmul_i8_amx(matmul_i8):
 
 def test_matmul_on_amx_scheduled_i8(compiler, sde64, matmul_i8):
     t = AMXTestBuilder(compiler.basename)
-    t.add_body([f"{compiler.basename}_Context *ctxt;"])
 
     # duplicate from the fixture above
     size1 = 256
@@ -377,11 +372,11 @@ def test_matmul_on_amx_scheduled_i8(compiler, sde64, matmul_i8):
     t.alloc_dram_2i32('z', size1, size1, '0')  # expected result
     t.alloc_dram_2i32('res', size1, size1, '0')
 
-    t.add_body([f'transform_memory(ctxt, {size2}, {size1}, y_orig, y);'])
+    t.add_body([f'transform_memory(NULL, {size2}, {size1}, y_orig, y);'])
     t.add_body(
-        [f'matmul_on_cpu(ctxt, {size1}, {size2}, {size1}, x, y_orig, z);'])
+        [f'matmul_on_cpu(NULL, {size1}, {size2}, {size1}, x, y_orig, z);'])
     t.add_body(
-        [f'matmul_on_amx(ctxt, x, y, res);'])
+        [f'matmul_on_amx(NULL, x, y, res);'])
 
     t.add_body([f'if(check_eq_2i32({size1}, {size1}, z, res)) {{',
                 '    printf("Correct\\n");',

--- a/tests/golden/pldi22/test_gemmini_conv_ae/test_conv_ae.txt
+++ b/tests/golden/pldi22/test_gemmini_conv_ae/test_conv_ae.txt
@@ -41,17 +41,21 @@ typedef struct c_code_str_Context {
     } ConfigStore;
 
 } c_code_str_Context;
-struct exo_win_2i32{
-    int32_t *data;
-    int_fast32_t strides[2];
+struct exo_win_2i32c{
+    const int32_t * const data;
+    const int_fast32_t strides[2];
 };
 struct exo_win_2i8{
-    int8_t *data;
-    int_fast32_t strides[2];
+    int8_t * const data;
+    const int_fast32_t strides[2];
 };
-struct exo_win_3i8{
-    int8_t *data;
-    int_fast32_t strides[3];
+struct exo_win_2i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_3i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[3];
 };
 // conv_on_gemmini(
 //     output : i8[4,56,56,64]  @DRAM,
@@ -61,18 +65,10 @@ struct exo_win_3i8{
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_on_gemmini( c_code_str_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_on_gemmini( c_code_str_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -119,7 +115,7 @@ gemmini_extended_config_st({dst_stride}, {act}, {scale}[0]);
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_on_gemmini( c_code_str_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_on_gemmini( c_code_str_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 gemmini_extended_config_st((64), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -156,7 +152,7 @@ for (int b = 0; b < 4; b++) {
             }
           }
           if (orow_ii + 7 * orow_io == 0 || false) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((0) * (3 * 4 * 4 * 16 * 16) + (0) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -204,7 +200,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || false) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (1) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((0) * (3 * 4 * 4 * 16 * 16) + (1) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -252,7 +248,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || false) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (2) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((0) * (3 * 4 * 4 * 16 * 16) + (2) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -300,7 +296,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || false) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((1 + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((1) * (3 * 4 * 4 * 16 * 16) + (0) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -348,7 +344,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || false) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((1 + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (1) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((1) * (3 * 4 * 4 * 16 * 16) + (1) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -396,7 +392,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || false) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((1 + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (2) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((1) * (3 * 4 * 4 * 16 * 16) + (2) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -444,7 +440,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || true) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((2 + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((2) * (3 * 4 * 4 * 16 * 16) + (0) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -492,7 +488,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || true) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (1 + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((2 + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (1) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((2) * (3 * 4 * 4 * 16 * 16) + (1) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -540,7 +536,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_ii + 7 * orow_io == 0 || true) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (2 + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((2 + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (2) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((2) * (3 * 4 * 4 * 16 * 16) + (2) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -601,7 +597,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || false) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((0) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((0) * (3 * 4 * 4 * 16 * 16) + (0) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -647,7 +643,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || false) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((1) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((0) * (3 * 4 * 4 * 16 * 16) + (1) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -693,7 +689,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || false) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((2) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((0) * (3 * 4 * 4 * 16 * 16) + (2) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -739,7 +735,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || false) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((0) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((1) * (3 * 4 * 4 * 16 * 16) + (0) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -785,7 +781,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || false) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((1) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((1) * (3 * 4 * 4 * 16 * 16) + (1) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -831,7 +827,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || false) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (1 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((2) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((1) * (3 * 4 * 4 * 16 * 16) + (2) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -877,7 +873,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || true) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((0) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((2) * (3 * 4 * 4 * 16 * 16) + (0) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -923,7 +919,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || true) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (49) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((1) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((2) * (3 * 4 * 4 * 16 * 16) + (1) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));
@@ -969,7 +965,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
           }
         }
         if (orow_ii + 7 * orow_io == 0 || true) {
-          gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+          gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (2 + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (50) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((2) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
         }
         gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s_1)) + ((2) * (3 * 4 * 4 * 16 * 16) + (2) * (4 * 4 * 16 * 16) + (0) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res_1)) + ((0) * (9 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (8));

--- a/tests/golden/pldi22/test_gemmini_matmul_ae/test_matmul_ae.txt
+++ b/tests/golden/pldi22/test_gemmini_matmul_ae/test_matmul_ae.txt
@@ -45,17 +45,21 @@ typedef struct c_code_str_Context {
     } ConfigStore;
 
 } c_code_str_Context;
-struct exo_win_2i32{
-    int32_t *data;
-    int_fast32_t strides[2];
+struct exo_win_2i32c{
+    const int32_t * const data;
+    const int_fast32_t strides[2];
 };
 struct exo_win_2i8{
-    int8_t *data;
-    int_fast32_t strides[2];
+    int8_t * const data;
+    const int_fast32_t strides[2];
 };
-struct exo_win_3i8{
-    int8_t *data;
-    int_fast32_t strides[3];
+struct exo_win_2i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_3i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[3];
 };
 // matmul_on_gemmini(
 //     scale : f32  @DRAM,
@@ -64,18 +68,10 @@ struct exo_win_3i8{
 //     B : i8[512,512]  @DRAM,
 //     C : i8[512,512]  @DRAM
 // )
-void matmul_on_gemmini( c_code_str_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_on_gemmini( c_code_str_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -153,7 +149,7 @@ gemmini_extended_mvin( 0, ((uint64_t) &{dst_data}),{m}, {n} );
 //     B : i8[512,512]  @DRAM,
 //     C : i8[512,512]  @DRAM
 // )
-void matmul_on_gemmini( c_code_str_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_on_gemmini( c_code_str_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((512), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);

--- a/tests/golden/test_apps/test_gemmini_conv.txt
+++ b/tests/golden/test_apps/test_gemmini_conv.txt
@@ -50,17 +50,21 @@ typedef struct test_case_Context {
     } ConfigStore;
 
 } test_case_Context;
-struct exo_win_2i32{
-    int32_t *data;
-    int_fast32_t strides[2];
+struct exo_win_2i32c{
+    const int32_t * const data;
+    const int_fast32_t strides[2];
 };
 struct exo_win_2i8{
-    int8_t *data;
-    int_fast32_t strides[2];
+    int8_t * const data;
+    const int_fast32_t strides[2];
 };
-struct exo_win_3i8{
-    int8_t *data;
-    int_fast32_t strides[3];
+struct exo_win_2i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_3i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[3];
 };
 // conv_17(
 //     output : i8[4,28,28,128]  @DRAM,
@@ -70,7 +74,7 @@ struct exo_win_3i8{
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_17( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_17( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 // conv_17_cpu(
 //     output : i8[4,28,28,128]  @DRAM,
@@ -80,7 +84,7 @@ void conv_17( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* in
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_17_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_17_cpu( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 // conv_3(
 //     output : i8[4,56,56,64]  @DRAM,
@@ -90,7 +94,7 @@ void conv_17_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_3( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_3( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 // conv_30(
 //     output : i8[4,14,14,256]  @DRAM,
@@ -100,7 +104,7 @@ void conv_3( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_30( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_30( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 // conv_30_cpu(
 //     output : i8[4,14,14,256]  @DRAM,
@@ -110,7 +114,7 @@ void conv_30( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* in
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_30_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_30_cpu( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 // conv_3_cpu(
 //     output : i8[4,56,56,64]  @DRAM,
@@ -120,7 +124,7 @@ void conv_30_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_3_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale );
+void conv_3_cpu( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale );
 
 
 
@@ -132,14 +136,6 @@ void conv_3_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t*
 #include "test_case.h"
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -162,7 +158,7 @@ double _select_(double x, double v, double y, double z) {
 //     src : f32  @DRAM,
 //     dst : i8  @DRAM
 // )
-static void clamp( test_case_Context *ctxt, float* src, int8_t* dst );
+static void clamp( test_case_Context *ctxt, const float* src, int8_t* dst );
 
 
 /* relying on the following instruction..."
@@ -173,7 +169,7 @@ acc_scale(src,dst,scale)
 //     src : f32  @DRAM,
 //     dst : i8  @DRAM
 // )
-static void clamp( test_case_Context *ctxt, float* src, int8_t* dst ) {
+static void clamp( test_case_Context *ctxt, const float* src, int8_t* dst ) {
 float l;
 float h;
 l = -128.0;
@@ -214,7 +210,7 @@ gemmini_extended_config_st({dst_stride}, {act}, {scale}[0]);
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_17( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_17( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 gemmini_extended_config_st((128), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -270,11 +266,11 @@ for (int bo = 0; bo < 1; bo++) {
             }
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (0) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (0) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (0) * (128) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (0) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (0) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (0) * (128) + (64) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (4) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((krow) * (3 * 8 * 8 * 16 * 16) + (0) * (8 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -436,11 +432,11 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (1) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (1) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (1) * (128) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 16 * 16) + (1) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (1) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (1) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (1) * (128) + (64) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 16 * 16) + (1) * (8 * 16 * 16) + (4) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((krow) * (3 * 8 * 8 * 16 * 16) + (1) * (8 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -602,11 +598,11 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (2) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (2) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (2) * (128) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 16 * 16) + (2) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (2) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (2) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (2) * (128) + (64) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 16 * 16) + (2) * (8 * 16 * 16) + (4) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((krow) * (3 * 8 * 8 * 16 * 16) + (2) * (8 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (16 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (16));
@@ -800,11 +796,11 @@ for (int bo = 0; bo < 1; bo++) {
             }
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (16) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (16) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (16) * (128) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 12 * 16) + (0) * (8 * 12 * 16) + (0) * (12 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (12) );
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (16) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (16) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (16) * (128) + (64) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 12 * 16) + (0) * (8 * 12 * 16) + (4) * (12 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (12) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((krow) * (3 * 8 * 8 * 16 * 16) + (0) * (8 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (13 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (12));
@@ -966,11 +962,11 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (17) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (17) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (17) * (128) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 12 * 16) + (1) * (8 * 12 * 16) + (0) * (12 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (12) );
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (17) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (17) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (17) * (128) + (64) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 12 * 16) + (1) * (8 * 12 * 16) + (4) * (12 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (12) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((krow) * (3 * 8 * 8 * 16 * 16) + (1) * (8 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (13 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (12));
@@ -1132,11 +1128,11 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
             }
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (18) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (18) * (128) + (0) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (18) * (128) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 12 * 16) + (2) * (8 * 12 * 16) + (0) * (12 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (12) );
           }
           if (orow_i == 0 || krow == 2) {
-            gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (18) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
+            gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (18) * (128) + (64) * (1)], { 128, 1 } }).strides[0]*1, 1.0f, 0, (12), 2);
 gemmini_extended_mvin3( &inp[(bi + 4 * bo) * (30 * 30 * 128) + (krow + orow_i + 14 * orow_o) * (30 * 128) + (18) * (128) + (64) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 8 * 12 * 16) + (2) * (8 * 12 * 16) + (4) * (12 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (12) );
           }
           gemmini_extended_preload((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)w_s)) + ((krow) * (3 * 8 * 8 * 16 * 16) + (2) * (8 * 8 * 16 * 16) + (0) * (8 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), (uint32_t)(&*(int32_t*)((uint64_t)( ((uint32_t)((uint64_t)res)) + ((0) * (13 * 16) + (0) * (16) + (0) * (1))/16))) | 0x40000000, (16), (16), (16), (12));
@@ -1293,7 +1289,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_17_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_17_cpu( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 EXO_ASSUME(28 == 30 - 3 + 1);
 for (int b = 0; b < 4; b++) {
   for (int orow = 0; orow < 28; orow++) {
@@ -1340,7 +1336,7 @@ for (int b = 0; b < 4; b++) {
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_3( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_3( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 gemmini_extended_config_st((64), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -1378,7 +1374,7 @@ for (int b = 0; b < 4; b++) {
                 }
               }
               if (orow_ii + 7 * orow_io == 0 || krow == 2) {
-                gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (krow + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (kcol + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
+                gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (krow + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (kcol + 16 * ocol_o) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (16), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (krow + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (kcol + 16 * ocol_o) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_ii + 7 * orow_io) * (3 * 4 * 16 * 16) + (kcol) * (4 * 16 * 16) + (0) * (16 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (16) );
               }
               for (int kch_o = 0; kch_o < 4; kch_o++) {
@@ -1420,7 +1416,7 @@ gemmini_extended_compute_preloaded((uint32_t)(&*(int8_t*)((uint64_t)( ((uint32_t
               }
             }
             if (orow_ii + 7 * orow_io == 0 || krow == 2) {
-              gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (58 * 58 * 64) + (krow + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48 + kcol) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
+              gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (58 * 58 * 64) + (krow + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48 + kcol) * (64) + (0) * (1)], { 64, 1 } }).strides[0]*1, 1.0f, 0, (8), 2);
 gemmini_extended_mvin3( &inp[(b) * (58 * 58 * 64) + (krow + orow_ii + 7 * orow_io + 28 * orow_o) * (58 * 64) + (48 + kcol) * (64) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s_1)) + ((krow + orow_ii + 7 * orow_io) * (3 * 4 * 8 * 16) + (kcol) * (4 * 8 * 16) + (0) * (8 * 16) + (0) * (16) + (0) * (1))/16))), 16*(4), (8) );
             }
             for (int kch_o = 0; kch_o < 4; kch_o++) {
@@ -1459,7 +1455,7 @@ gemm_free((uint64_t)(i_s));
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_30( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_30( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 gemmini_extended_config_st((256), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -1491,7 +1487,7 @@ for (int och_out = 0; och_out < 4; och_out++) {
               }
             }
             if (orow_i == 0 || krow == 2) {
-              gemmini_extended4_config_ld(((struct exo_win_2i8){ (int8_t*)&inp[(b) * (16 * 16 * 256) + (krow + orow_i + 7 * orow_o) * (16 * 256) + (kcol) * (256) + (0) * (1)], { 256, 1 } }).strides[0]*1, 1.0f, 0, (14), 2);
+              gemmini_extended4_config_ld(((struct exo_win_2i8c){ &inp[(b) * (16 * 16 * 256) + (krow + orow_i + 7 * orow_o) * (16 * 256) + (kcol) * (256) + (0) * (1)], { 256, 1 } }).strides[0]*1, 1.0f, 0, (14), 2);
 gemmini_extended_mvin3( &inp[(b) * (16 * 16 * 256) + (krow + orow_i + 7 * orow_o) * (16 * 256) + (kcol) * (256) + (0) * (1)], ((uint64_t) &*(int8_t*)((uint64_t)( ((uint32_t)((uint64_t)i_s)) + ((krow + orow_i) * (3 * 16 * 14 * 16) + (kcol) * (16 * 14 * 16) + (0) * (14 * 16) + (0) * (16) + (0) * (1))/16))), 16*(16), (14) );
             }
             for (int kch_o = 0; kch_o < 16; kch_o++) {
@@ -1527,7 +1523,7 @@ gemm_free((uint64_t)(i_s));
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_30_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_30_cpu( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 EXO_ASSUME(14 == 16 - 3 + 1);
 for (int b = 0; b < 4; b++) {
   for (int orow = 0; orow < 14; orow++) {
@@ -1574,7 +1570,7 @@ for (int b = 0; b < 4; b++) {
 //     act : bool,
 //     scale : f32  @DRAM
 // )
-void conv_3_cpu( test_case_Context *ctxt, int8_t* output, int32_t* bias, int8_t* inp, int8_t* weights, bool act, float* scale ) {
+void conv_3_cpu( test_case_Context *ctxt, int8_t* output, const int32_t* bias, const int8_t* inp, const int8_t* weights, bool act, const float* scale ) {
 EXO_ASSUME(56 == 58 - 3 + 1);
 for (int b = 0; b < 4; b++) {
   for (int orow = 0; orow < 56; orow++) {

--- a/tests/golden/test_apps/test_gemmini_matmul.txt
+++ b/tests/golden/test_apps/test_gemmini_matmul.txt
@@ -54,17 +54,21 @@ typedef struct test_case_Context {
     } ConfigStore;
 
 } test_case_Context;
-struct exo_win_2i32{
-    int32_t *data;
-    int_fast32_t strides[2];
+struct exo_win_2i32c{
+    const int32_t * const data;
+    const int_fast32_t strides[2];
 };
 struct exo_win_2i8{
-    int8_t *data;
-    int_fast32_t strides[2];
+    int8_t * const data;
+    const int_fast32_t strides[2];
 };
-struct exo_win_3i8{
-    int8_t *data;
-    int_fast32_t strides[3];
+struct exo_win_2i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_3i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[3];
 };
 // cpu_matmul_14(
 //     scale : f32  @DRAM,
@@ -73,7 +77,7 @@ struct exo_win_3i8{
 //     B : i8[128,512]  @DRAM,
 //     C : i8[3136,512]  @DRAM
 // )
-void cpu_matmul_14( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void cpu_matmul_14( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // cpu_matmul_16(
 //     scale : f32  @DRAM,
@@ -82,7 +86,7 @@ void cpu_matmul_14( test_case_Context *ctxt, float* scale, bool act, int8_t* A, 
 //     B : i8[512,128]  @DRAM,
 //     C : i8[3136,128]  @DRAM
 // )
-void cpu_matmul_16( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void cpu_matmul_16( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // cpu_matmul_27(
 //     scale : f32  @DRAM,
@@ -91,7 +95,7 @@ void cpu_matmul_16( test_case_Context *ctxt, float* scale, bool act, int8_t* A, 
 //     B : i8[256,1024]  @DRAM,
 //     C : i8[784,1024]  @DRAM
 // )
-void cpu_matmul_27( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void cpu_matmul_27( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // cpu_matmul_4(
 //     scale : f32  @DRAM,
@@ -100,7 +104,7 @@ void cpu_matmul_27( test_case_Context *ctxt, float* scale, bool act, int8_t* A, 
 //     B : i8[64,256]  @DRAM,
 //     C : i8[12544,256]  @DRAM
 // )
-void cpu_matmul_4( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void cpu_matmul_4( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // cpu_matmul_512x512x512(
 //     scale : f32  @DRAM,
@@ -109,7 +113,7 @@ void cpu_matmul_4( test_case_Context *ctxt, float* scale, bool act, int8_t* A, i
 //     B : i8[512,512]  @DRAM,
 //     C : i8[512,512]  @DRAM
 // )
-void cpu_matmul_512x512x512( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void cpu_matmul_512x512x512( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // cpu_matmul_6(
 //     scale : f32  @DRAM,
@@ -118,7 +122,7 @@ void cpu_matmul_512x512x512( test_case_Context *ctxt, float* scale, bool act, in
 //     B : i8[256,64]  @DRAM,
 //     C : i8[12544,64]  @DRAM
 // )
-void cpu_matmul_6( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void cpu_matmul_6( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // matmul_14(
 //     scale : f32  @DRAM,
@@ -127,7 +131,7 @@ void cpu_matmul_6( test_case_Context *ctxt, float* scale, bool act, int8_t* A, i
 //     B : i8[128,512]  @DRAM,
 //     C : i8[3136,512]  @DRAM
 // )
-void matmul_14( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_14( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // matmul_16(
 //     scale : f32  @DRAM,
@@ -136,7 +140,7 @@ void matmul_14( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8
 //     B : i8[512,128]  @DRAM,
 //     C : i8[3136,128]  @DRAM
 // )
-void matmul_16( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_16( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // matmul_27(
 //     scale : f32  @DRAM,
@@ -145,7 +149,7 @@ void matmul_16( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8
 //     B : i8[256,1024]  @DRAM,
 //     C : i8[784,1024]  @DRAM
 // )
-void matmul_27( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_27( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // matmul_4(
 //     scale : f32  @DRAM,
@@ -154,7 +158,7 @@ void matmul_27( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8
 //     B : i8[64,256]  @DRAM,
 //     C : i8[12544,256]  @DRAM
 // )
-void matmul_4( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_4( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // matmul_512x512x512(
 //     scale : f32  @DRAM,
@@ -163,7 +167,7 @@ void matmul_4( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_
 //     B : i8[512,512]  @DRAM,
 //     C : i8[512,512]  @DRAM
 // )
-void matmul_512x512x512( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_512x512x512( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 // matmul_6(
 //     scale : f32  @DRAM,
@@ -172,7 +176,7 @@ void matmul_512x512x512( test_case_Context *ctxt, float* scale, bool act, int8_t
 //     B : i8[256,64]  @DRAM,
 //     C : i8[12544,64]  @DRAM
 // )
-void matmul_6( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C );
+void matmul_6( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C );
 
 
 
@@ -184,14 +188,6 @@ void matmul_6( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_
 #include "test_case.h"
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -214,7 +210,7 @@ double _select_(double x, double v, double y, double z) {
 //     src : f32  @DRAM,
 //     dst : i8  @DRAM
 // )
-static void clamp( test_case_Context *ctxt, float* src, int8_t* dst );
+static void clamp( test_case_Context *ctxt, const float* src, int8_t* dst );
 
 
 /* relying on the following instruction..."
@@ -225,7 +221,7 @@ acc_scale(src,dst,scale)
 //     src : f32  @DRAM,
 //     dst : i8  @DRAM
 // )
-static void clamp( test_case_Context *ctxt, float* src, int8_t* dst ) {
+static void clamp( test_case_Context *ctxt, const float* src, int8_t* dst ) {
 float l;
 float h;
 l = -128.0;
@@ -271,7 +267,7 @@ gemmini_extended3_config_ld(0, 1.0f, 0, 0);
 //     B : i8[128,512]  @DRAM,
 //     C : i8[3136,512]  @DRAM
 // )
-void cpu_matmul_14( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void cpu_matmul_14( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 for (int i = 0; i < 3136; i++) {
   for (int j = 0; j < 512; j++) {
     int32_t res;
@@ -308,7 +304,7 @@ for (int i = 0; i < 3136; i++) {
 //     B : i8[512,128]  @DRAM,
 //     C : i8[3136,128]  @DRAM
 // )
-void cpu_matmul_16( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void cpu_matmul_16( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 for (int i = 0; i < 3136; i++) {
   for (int j = 0; j < 128; j++) {
     int32_t res;
@@ -345,7 +341,7 @@ for (int i = 0; i < 3136; i++) {
 //     B : i8[256,1024]  @DRAM,
 //     C : i8[784,1024]  @DRAM
 // )
-void cpu_matmul_27( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void cpu_matmul_27( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 for (int i = 0; i < 784; i++) {
   for (int j = 0; j < 1024; j++) {
     int32_t res;
@@ -382,7 +378,7 @@ for (int i = 0; i < 784; i++) {
 //     B : i8[64,256]  @DRAM,
 //     C : i8[12544,256]  @DRAM
 // )
-void cpu_matmul_4( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void cpu_matmul_4( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 for (int i = 0; i < 12544; i++) {
   for (int j = 0; j < 256; j++) {
     int32_t res;
@@ -419,7 +415,7 @@ for (int i = 0; i < 12544; i++) {
 //     B : i8[512,512]  @DRAM,
 //     C : i8[512,512]  @DRAM
 // )
-void cpu_matmul_512x512x512( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void cpu_matmul_512x512x512( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 for (int i = 0; i < 512; i++) {
   for (int j = 0; j < 512; j++) {
     int32_t res;
@@ -456,7 +452,7 @@ for (int i = 0; i < 512; i++) {
 //     B : i8[256,64]  @DRAM,
 //     C : i8[12544,64]  @DRAM
 // )
-void cpu_matmul_6( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void cpu_matmul_6( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 for (int i = 0; i < 12544; i++) {
   for (int j = 0; j < 64; j++) {
     int32_t res;
@@ -519,7 +515,7 @@ gemmini_extended_mvin( 0, ((uint64_t) &{dst_data}),{m}, {n} );
 //     B : i8[128,512]  @DRAM,
 //     C : i8[3136,512]  @DRAM
 // )
-void matmul_14( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_14( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((512), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -616,7 +612,7 @@ gemm_acc_free((uint32_t)(res));
 //     B : i8[512,128]  @DRAM,
 //     C : i8[3136,128]  @DRAM
 // )
-void matmul_16( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_16( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((128), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -713,7 +709,7 @@ gemm_acc_free((uint32_t)(res));
 //     B : i8[256,1024]  @DRAM,
 //     C : i8[784,1024]  @DRAM
 // )
-void matmul_27( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_27( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((1024), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -806,7 +802,7 @@ gemm_acc_free((uint32_t)(res));
 //     B : i8[64,256]  @DRAM,
 //     C : i8[12544,256]  @DRAM
 // )
-void matmul_4( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_4( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((256), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -901,7 +897,7 @@ gemm_free((uint64_t)(a));
 //     B : i8[512,512]  @DRAM,
 //     C : i8[512,512]  @DRAM
 // )
-void matmul_512x512x512( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_512x512x512( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((512), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);
@@ -1004,7 +1000,7 @@ gemm_free((uint64_t)(a));
 //     B : i8[256,64]  @DRAM,
 //     C : i8[12544,64]  @DRAM
 // )
-void matmul_6( test_case_Context *ctxt, float* scale, bool act, int8_t* A, int8_t* B, int8_t* C ) {
+void matmul_6( test_case_Context *ctxt, const float* scale, bool act, const int8_t* A, const int8_t* B, int8_t* C ) {
 gemmini_extended_config_st((64), (act), (scale)[0]);
 
 gemmini_extended_config_ex(WS, 0, 0, 0, 1, 0, 0);

--- a/tests/golden/test_apps/test_neon_sgemm.txt
+++ b/tests/golden/test_apps/test_neon_sgemm.txt
@@ -66,14 +66,6 @@ void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, cons
 #include "test_case.h"
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_apps/test_neon_sgemm.txt
+++ b/tests/golden/test_apps/test_neon_sgemm.txt
@@ -48,7 +48,7 @@ struct exo_win_2f32{
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, float* A, float* B, float* C );
+void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C );
 
 
 
@@ -149,7 +149,7 @@ vst1q_f32(&{dst_data}, {src_data});
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, float* A, float* B, float* C ) {
+void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);

--- a/tests/golden/test_apps/test_neon_sgemm.txt
+++ b/tests/golden/test_apps/test_neon_sgemm.txt
@@ -29,9 +29,7 @@ extern "C" {
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct test_case_Context { 
 
-} test_case_Context;
 struct exo_win_1f32{
     float * const data;
     const int_fast32_t strides[1];
@@ -56,7 +54,7 @@ struct exo_win_2f32c{
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C );
+void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C );
 
 
 
@@ -88,7 +86,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     B : [f32][K,16]  @DRAM,
 //     C : [f32][4,16]  @DRAM
 // )
-static void neon_microkernel( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void neon_microkernel( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 
 /* relying on the following instruction..."
@@ -101,7 +99,7 @@ neon_broadcast_4xf32(dst,src)
 //     B : [f32][K,16]  @DRAM,
 //     C : [f32][4,16]  @DRAM
 // )
-static void neon_microkernel( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void neon_microkernel( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -157,7 +155,7 @@ vst1q_f32(&{dst_data}, {src_data});
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C ) {
+void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);

--- a/tests/golden/test_apps/test_neon_sgemm.txt
+++ b/tests/golden/test_apps/test_neon_sgemm.txt
@@ -33,12 +33,20 @@ typedef struct test_case_Context {
 
 } test_case_Context;
 struct exo_win_1f32{
-    float *data;
-    int_fast32_t strides[1];
+    float * const data;
+    const int_fast32_t strides[1];
+};
+struct exo_win_1f32c{
+    const float * const data;
+    const int_fast32_t strides[1];
 };
 struct exo_win_2f32{
-    float *data;
-    int_fast32_t strides[2];
+    float * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_2f32c{
+    const float * const data;
+    const int_fast32_t strides[2];
 };
 // sgemm_exo(
 //     M : size,
@@ -80,7 +88,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     B : [f32][K,16]  @DRAM,
 //     C : [f32][4,16]  @DRAM
 // )
-static void neon_microkernel( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void neon_microkernel( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 
 /* relying on the following instruction..."
@@ -93,7 +101,7 @@ neon_broadcast_4xf32(dst,src)
 //     B : [f32][K,16]  @DRAM,
 //     C : [f32][4,16]  @DRAM
 // )
-static void neon_microkernel( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void neon_microkernel( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -173,7 +181,7 @@ for (int ko = 0; ko < ((K) / (64)); ko++) {
       }
       for (int im = 0; im < 16; im++) {
         for (int jm = 0; jm < 4; jm++) {
-          neon_microkernel(ctxt,64,(struct exo_win_2f32){ (float*)&Atile[(4 * im) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&Btile[(0) * (64) + (16 * jm) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(4 * im + 64 * io) * (N) + (16 * jm + 64 * jo) * (1)], { N, 1 } });
+          neon_microkernel(ctxt,64,(struct exo_win_2f32c){ &Atile[(4 * im) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32c){ &Btile[(0) * (64) + (16 * jm) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(4 * im + 64 * io) * (N) + (16 * jm + 64 * jo) * (1)], { N, 1 } });
         }
       }
     }
@@ -185,13 +193,13 @@ for (int ko = 0; ko < ((K) / (64)); ko++) {
   for (int io = 0; io < ((((M) / (4))) / (16)); io++) {
     for (int jm = 0; jm < ((N) / (16)) % 4; jm++) {
       for (int im = 0; im < 16; im++) {
-        neon_microkernel(ctxt,64,(struct exo_win_2f32){ (float*)&A[(4 * im + 64 * io) * (K) + (64 * ko) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B[(64 * ko) * (N) + (16 * (jm + ((((N) / (16))) / (4)) * 4)) * (1)], { N, 1 } },(struct exo_win_2f32){ (float*)&C[(4 * im + 64 * io) * (N) + (16 * (jm + ((((N) / (16))) / (4)) * 4)) * (1)], { N, 1 } });
+        neon_microkernel(ctxt,64,(struct exo_win_2f32c){ &A[(4 * im + 64 * io) * (K) + (64 * ko) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B[(64 * ko) * (N) + (16 * (jm + ((((N) / (16))) / (4)) * 4)) * (1)], { N, 1 } },(struct exo_win_2f32){ &C[(4 * im + 64 * io) * (N) + (16 * (jm + ((((N) / (16))) / (4)) * 4)) * (1)], { N, 1 } });
       }
     }
   }
   for (int jo = 0; jo < ((N) / (16)); jo++) {
     for (int im = 0; im < ((M) / (4)) % 16; im++) {
-      neon_microkernel(ctxt,64,(struct exo_win_2f32){ (float*)&A[(4 * (im + ((((M) / (4))) / (16)) * 16)) * (K) + (64 * ko) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B[(64 * ko) * (N) + (16 * jo) * (1)], { N, 1 } },(struct exo_win_2f32){ (float*)&C[(4 * (im + ((((M) / (4))) / (16)) * 16)) * (N) + (16 * jo) * (1)], { N, 1 } });
+      neon_microkernel(ctxt,64,(struct exo_win_2f32c){ &A[(4 * (im + ((((M) / (4))) / (16)) * 16)) * (K) + (64 * ko) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B[(64 * ko) * (N) + (16 * jo) * (1)], { N, 1 } },(struct exo_win_2f32){ &C[(4 * (im + ((((M) / (4))) / (16)) * 16)) * (N) + (16 * jo) * (1)], { N, 1 } });
     }
   }
 }

--- a/tests/golden/test_apps/test_x86_conv.txt
+++ b/tests/golden/test_apps/test_x86_conv.txt
@@ -33,8 +33,12 @@ typedef struct test_case_Context {
 
 } test_case_Context;
 struct exo_win_1f32{
-    float *data;
-    int_fast32_t strides[1];
+    float * const data;
+    const int_fast32_t strides[1];
+};
+struct exo_win_1f32c{
+    const float * const data;
+    const int_fast32_t strides[1];
 };
 // conv_specialized(
 //     inp : f32[5,82,102,128]  @DRAM,

--- a/tests/golden/test_apps/test_x86_conv.txt
+++ b/tests/golden/test_apps/test_x86_conv.txt
@@ -29,9 +29,7 @@ extern "C" {
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct test_case_Context { 
 
-} test_case_Context;
 struct exo_win_1f32{
     float * const data;
     const int_fast32_t strides[1];
@@ -46,7 +44,7 @@ struct exo_win_1f32c{
 //     weights : f32[128,3,3,128]  @DRAM,
 //     bias : f32[128]  @DRAM
 // )
-void conv_specialized( test_case_Context *ctxt, const float* inp, float* output, const float* weights, const float* bias );
+void conv_specialized( void *ctxt, const float* inp, float* output, const float* weights, const float* bias );
 
 
 
@@ -83,7 +81,7 @@ double _relu_(double x) {
 //     weights : f32[128,3,3,128]  @DRAM,
 //     bias : f32[128]  @DRAM
 // )
-void conv_specialized( test_case_Context *ctxt, const float* inp, float* output, const float* weights, const float* bias ) {
+void conv_specialized( void *ctxt, const float* inp, float* output, const float* weights, const float* bias ) {
 for (int oc_o = 0; oc_o < 2; oc_o++) {
   for (int n = 0; n < 5; n++) {
     for (int oy = 0; oy < 80; oy++) {

--- a/tests/golden/test_apps/test_x86_conv.txt
+++ b/tests/golden/test_apps/test_x86_conv.txt
@@ -42,7 +42,7 @@ struct exo_win_1f32{
 //     weights : f32[128,3,3,128]  @DRAM,
 //     bias : f32[128]  @DRAM
 // )
-void conv_specialized( test_case_Context *ctxt, float* inp, float* output, float* weights, float* bias );
+void conv_specialized( test_case_Context *ctxt, const float* inp, float* output, const float* weights, const float* bias );
 
 
 
@@ -79,7 +79,7 @@ double _relu_(double x) {
 //     weights : f32[128,3,3,128]  @DRAM,
 //     bias : f32[128]  @DRAM
 // )
-void conv_specialized( test_case_Context *ctxt, float* inp, float* output, float* weights, float* bias ) {
+void conv_specialized( test_case_Context *ctxt, const float* inp, float* output, const float* weights, const float* bias ) {
 for (int oc_o = 0; oc_o < 2; oc_o++) {
   for (int n = 0; n < 5; n++) {
     for (int oy = 0; oy < 80; oy++) {

--- a/tests/golden/test_apps/test_x86_conv.txt
+++ b/tests/golden/test_apps/test_x86_conv.txt
@@ -56,14 +56,6 @@ void conv_specialized( void *ctxt, const float* inp, float* output, const float*
 #include "test_case.h"
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <immintrin.h>
 #include <stdio.h>

--- a/tests/golden/test_apps/test_x86_sgemm.txt
+++ b/tests/golden/test_apps/test_x86_sgemm.txt
@@ -48,7 +48,7 @@ struct exo_win_2f32{
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, float* A, float* B, float* C );
+void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C );
 
 
 
@@ -450,7 +450,7 @@ if (M % 6 > 0) {
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, float* A, float* B, float* C ) {
+void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);

--- a/tests/golden/test_apps/test_x86_sgemm.txt
+++ b/tests/golden/test_apps/test_x86_sgemm.txt
@@ -66,14 +66,6 @@ void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, cons
 #include "test_case.h"
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <immintrin.h>
 #include <stdio.h>

--- a/tests/golden/test_apps/test_x86_sgemm.txt
+++ b/tests/golden/test_apps/test_x86_sgemm.txt
@@ -33,12 +33,20 @@ typedef struct test_case_Context {
 
 } test_case_Context;
 struct exo_win_1f32{
-    float *data;
-    int_fast32_t strides[1];
+    float * const data;
+    const int_fast32_t strides[1];
+};
+struct exo_win_1f32c{
+    const float * const data;
+    const int_fast32_t strides[1];
 };
 struct exo_win_2f32{
-    float *data;
-    int_fast32_t strides[2];
+    float * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_2f32c{
+    const float * const data;
+    const int_fast32_t strides[2];
 };
 // sgemm_exo(
 //     M : size,
@@ -84,7 +92,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][M,64]  @DRAM
 // )
-static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // right_panel_kernel_scheduled(
 //     N : size,
@@ -93,7 +101,7 @@ static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][6,N]  @DRAM
 // )
-static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_above_kernel(
 //     M : size,
@@ -103,7 +111,7 @@ static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t 
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][M,N]  @DRAM
 // )
-static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_1x4(
 //     K : size,
@@ -111,7 +119,7 @@ static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fas
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][1,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_2x4(
 //     K : size,
@@ -119,7 +127,7 @@ static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][2,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_3x4(
 //     K : size,
@@ -127,7 +135,7 @@ static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][3,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_4x4(
 //     K : size,
@@ -135,7 +143,7 @@ static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][4,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_5x4(
 //     K : size,
@@ -143,7 +151,7 @@ static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][5,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_6x4(
 //     K : size,
@@ -151,7 +159,7 @@ static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][6,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // bottom_panel_kernel_scheduled(
 //     M : size,
@@ -160,7 +168,7 @@ static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][M,64]  @DRAM
 // )
-static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
@@ -168,19 +176,19 @@ EXO_ASSUME(B.strides[1] == 1);
 EXO_ASSUME(C.strides[1] == 1);
 EXO_ASSUME(M < 6);
 if (M == 1) {
-  sgemm_kernel_avx512_1x4(ctxt,K,(struct exo_win_2f32){ (float*)&A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+  sgemm_kernel_avx512_1x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
 } else {
   if (M == 2) {
-    sgemm_kernel_avx512_2x4(ctxt,K,(struct exo_win_2f32){ (float*)&A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    sgemm_kernel_avx512_2x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
   } else {
     if (M == 3) {
-      sgemm_kernel_avx512_3x4(ctxt,K,(struct exo_win_2f32){ (float*)&A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+      sgemm_kernel_avx512_3x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
     } else {
       if (M == 4) {
-        sgemm_kernel_avx512_4x4(ctxt,K,(struct exo_win_2f32){ (float*)&A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+        sgemm_kernel_avx512_4x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
       } else {
         if (M == 5) {
-          sgemm_kernel_avx512_5x4(ctxt,K,(struct exo_win_2f32){ (float*)&A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+          sgemm_kernel_avx512_5x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
         } else {
           for (int k = 0; k < K; k++) {
             for (int i = 0; i < M; i++) {
@@ -243,7 +251,7 @@ _mm512_storeu_ps(&{dst_data}, {src_data});
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][6,N]  @DRAM
 // )
-static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
@@ -409,7 +417,7 @@ if (((N) / (16)) == 0) {
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][M,N]  @DRAM
 // )
-static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
@@ -418,17 +426,17 @@ EXO_ASSUME(B.strides[1] == 1);
 EXO_ASSUME(C.strides[1] == 1);
 for (int io = 0; io < ((M) / (6)); io++) {
   for (int jo = 0; jo < ((N) / (64)); jo++) {
-    sgemm_kernel_avx512_6x4(ctxt,K,(struct exo_win_2f32){ (float*)&A.data[(6 * io) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (64 * jo) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(6 * io) * (C.strides[0]) + (64 * jo) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    sgemm_kernel_avx512_6x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(6 * io) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * jo) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(6 * io) * (C.strides[0]) + (64 * jo) * (C.strides[1])], { C.strides[0], C.strides[1] } });
   }
 }
 if (N % 64 > 0) {
   for (int io = 0; io < ((M) / (6)); io++) {
-    right_panel_kernel_scheduled(ctxt,N % 64,K,(struct exo_win_2f32){ (float*)&A.data[(6 * io) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (64 * ((N) / (64))) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(6 * io) * (C.strides[0]) + (64 * ((N) / (64))) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    right_panel_kernel_scheduled(ctxt,N % 64,K,(struct exo_win_2f32c){ &A.data[(6 * io) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * ((N) / (64))) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(6 * io) * (C.strides[0]) + (64 * ((N) / (64))) * (C.strides[1])], { C.strides[0], C.strides[1] } });
   }
 }
 if (M % 6 > 0) {
   for (int jo = 0; jo < ((N) / (64)); jo++) {
-    bottom_panel_kernel_scheduled(ctxt,M % 6,K,(struct exo_win_2f32){ (float*)&A.data[(6 * ((M) / (6))) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32){ (float*)&B.data[(0) * (B.strides[0]) + (64 * jo) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ (float*)&C.data[(6 * ((M) / (6))) * (C.strides[0]) + (64 * jo) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    bottom_panel_kernel_scheduled(ctxt,M % 6,K,(struct exo_win_2f32c){ &A.data[(6 * ((M) / (6))) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * jo) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(6 * ((M) / (6))) * (C.strides[0]) + (64 * jo) * (C.strides[1])], { C.strides[0], C.strides[1] } });
   }
   if (N % 64 > 0) {
     for (int k = 0; k < K; k++) {
@@ -472,7 +480,7 @@ for (int ko = 0; ko < ((K) / (512)); ko++) {
           B1_cache[(i0) * (64) + (i1) * (1)] = B[(i0 + 512 * ko) * (N) + (i1 + 64 * jo) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,264,64,512,(struct exo_win_2f32){ (float*)&A1_cache[(0) * (512) + (0) * (1)], { 512, 1 } },(struct exo_win_2f32){ (float*)&B1_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * io) * (N) + (64 * jo) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,264,64,512,(struct exo_win_2f32c){ &A1_cache[(0) * (512) + (0) * (1)], { 512, 1 } },(struct exo_win_2f32c){ &B1_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * io) * (N) + (64 * jo) * (1)], { N, 1 } });
     }
   }
 }
@@ -485,7 +493,7 @@ if (N % 64 > 0) {
       }
     }
     for (int io = 0; io < ((M) / (264)); io++) {
-      sgemm_above_kernel(ctxt,264,N % 64,512,(struct exo_win_2f32){ (float*)&A[(264 * io) * (K) + (512 * ko) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B2_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * io) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,264,N % 64,512,(struct exo_win_2f32c){ &A[(264 * io) * (K) + (512 * ko) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B2_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * io) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
     }
   }
 }
@@ -498,7 +506,7 @@ if (M % 264 > 0) {
           B3_cache[(i0) * (64) + (i1) * (1)] = B[(i0 + 512 * ko) * (N) + (i1 + 64 * jo) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,M % 264,64,512,(struct exo_win_2f32){ (float*)&A[(264 * ((M) / (264))) * (K) + (512 * ko) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B3_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * ((M) / (264))) * (N) + (64 * jo) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,M % 264,64,512,(struct exo_win_2f32c){ &A[(264 * ((M) / (264))) * (K) + (512 * ko) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B3_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * ((M) / (264))) * (N) + (64 * jo) * (1)], { N, 1 } });
     }
   }
 }
@@ -511,7 +519,7 @@ if (M % 264 > 0) {
           B4_cache[(i0) * (64) + (i1) * (1)] = B[(i0 + 512 * ko) * (N) + (64 * ((N) / (64)) + i1) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,M % 264,N % 64,512,(struct exo_win_2f32){ (float*)&A[(264 * ((M) / (264))) * (K) + (512 * ko) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B4_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * ((M) / (264))) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,M % 264,N % 64,512,(struct exo_win_2f32c){ &A[(264 * ((M) / (264))) * (K) + (512 * ko) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B4_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * ((M) / (264))) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
     }
   }
 }
@@ -524,7 +532,7 @@ if (K % 512 > 0) {
           B5_cache[(i0) * (64) + (i1) * (1)] = B[(512 * ((K) / (512)) + i0) * (N) + (i1 + 64 * jo) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,264,64,K % 512,(struct exo_win_2f32){ (float*)&A[(264 * io) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B5_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * io) * (N) + (64 * jo) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,264,64,K % 512,(struct exo_win_2f32c){ &A[(264 * io) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B5_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * io) * (N) + (64 * jo) * (1)], { N, 1 } });
     }
   }
 }
@@ -537,7 +545,7 @@ if (K % 512 > 0) {
           B6_cache[(i0) * (64) + (i1) * (1)] = B[(512 * ((K) / (512)) + i0) * (N) + (64 * ((N) / (64)) + i1) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,264,N % 64,K % 512,(struct exo_win_2f32){ (float*)&A[(264 * io) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B6_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * io) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,264,N % 64,K % 512,(struct exo_win_2f32c){ &A[(264 * io) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B6_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * io) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
     }
   }
 }
@@ -550,7 +558,7 @@ if (K % 512 > 0) {
           B7_cache[(i0) * (64) + (i1) * (1)] = B[(512 * ((K) / (512)) + i0) * (N) + (i1 + 64 * jo) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,M % 264,64,K % 512,(struct exo_win_2f32){ (float*)&A[(264 * ((M) / (264))) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B7_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * ((M) / (264))) * (N) + (64 * jo) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,M % 264,64,K % 512,(struct exo_win_2f32c){ &A[(264 * ((M) / (264))) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B7_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * ((M) / (264))) * (N) + (64 * jo) * (1)], { N, 1 } });
     }
   }
 }
@@ -563,7 +571,7 @@ if (K % 512 > 0) {
           B8_cache[(i0) * (64) + (i1) * (1)] = B[(512 * ((K) / (512)) + i0) * (N) + (64 * ((N) / (64)) + i1) * (1)];
         }
       }
-      sgemm_above_kernel(ctxt,M % 264,N % 64,K % 512,(struct exo_win_2f32){ (float*)&A[(264 * ((M) / (264))) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32){ (float*)&B8_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ (float*)&C[(264 * ((M) / (264))) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
+      sgemm_above_kernel(ctxt,M % 264,N % 64,K % 512,(struct exo_win_2f32c){ &A[(264 * ((M) / (264))) * (K) + (512 * ((K) / (512))) * (1)], { K, 1 } },(struct exo_win_2f32c){ &B8_cache[(0) * (64) + (0) * (1)], { 64, 1 } },(struct exo_win_2f32){ &C[(264 * ((M) / (264))) * (N) + (64 * ((N) / (64))) * (1)], { N, 1 } });
     }
   }
 }
@@ -575,7 +583,7 @@ if (K % 512 > 0) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][1,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -610,7 +618,7 @@ for (int i = 0; i < 1; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][2,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -645,7 +653,7 @@ for (int i = 0; i < 2; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][3,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -680,7 +688,7 @@ for (int i = 0; i < 3; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][4,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -715,7 +723,7 @@ for (int i = 0; i < 4; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][5,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -750,7 +758,7 @@ for (int i = 0; i < 5; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][6,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32 A, struct exo_win_2f32 B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);

--- a/tests/golden/test_apps/test_x86_sgemm.txt
+++ b/tests/golden/test_apps/test_x86_sgemm.txt
@@ -29,9 +29,7 @@ extern "C" {
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct test_case_Context { 
 
-} test_case_Context;
 struct exo_win_1f32{
     float * const data;
     const int_fast32_t strides[1];
@@ -56,7 +54,7 @@ struct exo_win_2f32c{
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C );
+void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C );
 
 
 
@@ -92,7 +90,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][M,64]  @DRAM
 // )
-static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void bottom_panel_kernel_scheduled( void *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // right_panel_kernel_scheduled(
 //     N : size,
@@ -101,7 +99,7 @@ static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][6,N]  @DRAM
 // )
-static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void right_panel_kernel_scheduled( void *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_above_kernel(
 //     M : size,
@@ -111,7 +109,7 @@ static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t 
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][M,N]  @DRAM
 // )
-static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_above_kernel( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_1x4(
 //     K : size,
@@ -119,7 +117,7 @@ static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fas
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][1,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_1x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_2x4(
 //     K : size,
@@ -127,7 +125,7 @@ static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][2,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_2x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_3x4(
 //     K : size,
@@ -135,7 +133,7 @@ static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][3,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_3x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_4x4(
 //     K : size,
@@ -143,7 +141,7 @@ static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][4,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_4x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_5x4(
 //     K : size,
@@ -151,7 +149,7 @@ static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][5,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_5x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // sgemm_kernel_avx512_6x4(
 //     K : size,
@@ -159,7 +157,7 @@ static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][6,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
+static void sgemm_kernel_avx512_6x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C );
 
 // bottom_panel_kernel_scheduled(
 //     M : size,
@@ -168,7 +166,7 @@ static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, st
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][M,64]  @DRAM
 // )
-static void bottom_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void bottom_panel_kernel_scheduled( void *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
@@ -251,7 +249,7 @@ _mm512_storeu_ps(&{dst_data}, {src_data});
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][6,N]  @DRAM
 // )
-static void right_panel_kernel_scheduled( test_case_Context *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void right_panel_kernel_scheduled( void *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
@@ -417,7 +415,7 @@ if (((N) / (16)) == 0) {
 //     B : [f32][K,N]  @DRAM,
 //     C : [f32][M,N]  @DRAM
 // )
-static void sgemm_above_kernel( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_above_kernel( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
@@ -458,7 +456,7 @@ if (M % 6 > 0) {
 //     B : f32[K,N]  @DRAM,
 //     C : f32[M,N]  @DRAM
 // )
-void sgemm_exo( test_case_Context *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C ) {
+void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, const float* A, const float* B, float* C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
@@ -583,7 +581,7 @@ if (K % 512 > 0) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][1,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_1x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_1x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -618,7 +616,7 @@ for (int i = 0; i < 1; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][2,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_2x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_2x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -653,7 +651,7 @@ for (int i = 0; i < 2; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][3,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_3x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_3x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -688,7 +686,7 @@ for (int i = 0; i < 3; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][4,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_4x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_4x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -723,7 +721,7 @@ for (int i = 0; i < 4; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][5,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_5x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_5x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);
@@ -758,7 +756,7 @@ for (int i = 0; i < 5; i++) {
 //     B : [f32][K,64]  @DRAM,
 //     C : [f32][6,64]  @DRAM
 // )
-static void sgemm_kernel_avx512_6x4( test_case_Context *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
+static void sgemm_kernel_avx512_6x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
 EXO_ASSUME(A.strides[1] == 1);
 EXO_ASSUME(B.strides[1] == 1);

--- a/tests/golden/test_codegen/test_const_buffer_parameters.txt
+++ b/tests/golden/test_codegen/test_const_buffer_parameters.txt
@@ -69,14 +69,6 @@ void memcpy_b( void *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B );
 #include "test.h"
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_codegen/test_const_buffer_parameters.txt
+++ b/tests/golden/test_codegen/test_const_buffer_parameters.txt
@@ -1,0 +1,120 @@
+
+#pragma once
+#ifndef TEST_H
+#define TEST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Compiler feature macros adapted from Hedley (public domain)
+// https://github.com/nemequ/hedley
+
+#if defined(__has_builtin)
+#  define EXO_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+#  define EXO_HAS_BUILTIN(builtin) (0)
+#endif
+
+#if EXO_HAS_BUILTIN(__builtin_assume)
+#  define EXO_ASSUME(expr) __builtin_assume(expr)
+#elif EXO_HAS_BUILTIN(__builtin_unreachable)
+#  define EXO_ASSUME(expr) \
+      ((void)((expr) ? 1 : (__builtin_unreachable(), 1)))
+#else
+#  define EXO_ASSUME(expr) ((void)(expr))
+#endif
+
+typedef struct test_Context { 
+
+} test_Context;
+struct exo_win_1f32{
+    float * const data;
+    const int_fast32_t strides[1];
+};
+struct exo_win_1f32c{
+    const float * const data;
+    const int_fast32_t strides[1];
+};
+// memcpy(
+//     N : size,
+//     A : f32[N]  @DRAM,
+//     B : f32[N]  @DRAM
+// )
+void memcpy( test_Context *ctxt, int_fast32_t N, float* A, const float* B );
+
+// memcpy_ab(
+//     N : size,
+//     A : [f32][N]  @DRAM,
+//     B : [f32][N]  @DRAM
+// )
+void memcpy_ab( test_Context *ctxt, int_fast32_t N, struct exo_win_1f32 A, struct exo_win_1f32c B );
+
+// memcpy_b(
+//     N : size,
+//     A : f32[N]  @DRAM,
+//     B : [f32][N]  @DRAM
+// )
+void memcpy_b( test_Context *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B );
+
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // TEST_H
+
+#include "test.h"
+
+
+static int _floor_div(int num, int quot) {
+  int off = (num>=0)? 0 : quot-1;
+  return (num-off)/quot;
+}
+
+static int8_t _clamp_32to8(int32_t x) {
+  return (x < -128)? -128 : ((x > 127)? 127 : x);
+}
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+
+// memcpy(
+//     N : size,
+//     A : f32[N]  @DRAM,
+//     B : f32[N]  @DRAM
+// )
+void memcpy( test_Context *ctxt, int_fast32_t N, float* A, const float* B ) {
+for (int i = 0; i < N; i++) {
+  A[(i) * (1)] = B[(i) * (1)];
+}
+}
+
+// memcpy_ab(
+//     N : size,
+//     A : [f32][N]  @DRAM,
+//     B : [f32][N]  @DRAM
+// )
+void memcpy_ab( test_Context *ctxt, int_fast32_t N, struct exo_win_1f32 A, struct exo_win_1f32c B ) {
+for (int i = 0; i < N; i++) {
+  A.data[(i) * (A.strides[0])] = B.data[(i) * (B.strides[0])];
+}
+}
+
+// memcpy_b(
+//     N : size,
+//     A : f32[N]  @DRAM,
+//     B : [f32][N]  @DRAM
+// )
+void memcpy_b( test_Context *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B ) {
+for (int i = 0; i < N; i++) {
+  A[(i) * (1)] = B.data[(i) * (B.strides[0])];
+}
+}
+

--- a/tests/golden/test_codegen/test_const_buffer_parameters.txt
+++ b/tests/golden/test_codegen/test_const_buffer_parameters.txt
@@ -29,9 +29,7 @@ extern "C" {
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct test_Context { 
 
-} test_Context;
 struct exo_win_1f32{
     float * const data;
     const int_fast32_t strides[1];
@@ -45,21 +43,21 @@ struct exo_win_1f32c{
 //     A : f32[N]  @DRAM,
 //     B : f32[N]  @DRAM
 // )
-void memcpy( test_Context *ctxt, int_fast32_t N, float* A, const float* B );
+void memcpy( void *ctxt, int_fast32_t N, float* A, const float* B );
 
 // memcpy_ab(
 //     N : size,
 //     A : [f32][N]  @DRAM,
 //     B : [f32][N]  @DRAM
 // )
-void memcpy_ab( test_Context *ctxt, int_fast32_t N, struct exo_win_1f32 A, struct exo_win_1f32c B );
+void memcpy_ab( void *ctxt, int_fast32_t N, struct exo_win_1f32 A, struct exo_win_1f32c B );
 
 // memcpy_b(
 //     N : size,
 //     A : f32[N]  @DRAM,
 //     B : [f32][N]  @DRAM
 // )
-void memcpy_b( test_Context *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B );
+void memcpy_b( void *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B );
 
 
 
@@ -90,7 +88,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     A : f32[N]  @DRAM,
 //     B : f32[N]  @DRAM
 // )
-void memcpy( test_Context *ctxt, int_fast32_t N, float* A, const float* B ) {
+void memcpy( void *ctxt, int_fast32_t N, float* A, const float* B ) {
 for (int i = 0; i < N; i++) {
   A[(i) * (1)] = B[(i) * (1)];
 }
@@ -101,7 +99,7 @@ for (int i = 0; i < N; i++) {
 //     A : [f32][N]  @DRAM,
 //     B : [f32][N]  @DRAM
 // )
-void memcpy_ab( test_Context *ctxt, int_fast32_t N, struct exo_win_1f32 A, struct exo_win_1f32c B ) {
+void memcpy_ab( void *ctxt, int_fast32_t N, struct exo_win_1f32 A, struct exo_win_1f32c B ) {
 for (int i = 0; i < N; i++) {
   A.data[(i) * (A.strides[0])] = B.data[(i) * (B.strides[0])];
 }
@@ -112,7 +110,7 @@ for (int i = 0; i < N; i++) {
 //     A : f32[N]  @DRAM,
 //     B : [f32][N]  @DRAM
 // )
-void memcpy_b( test_Context *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B ) {
+void memcpy_b( void *ctxt, int_fast32_t N, float* A, struct exo_win_1f32c B ) {
 for (int i = 0; i < N; i++) {
   A[(i) * (1)] = B.data[(i) * (B.strides[0])];
 }

--- a/tests/golden/test_precision/test_good_prec2.txt
+++ b/tests/golden/test_precision/test_good_prec2.txt
@@ -31,14 +31,6 @@ void hoge( void *ctxt, int_fast32_t n, const float* x, const float* y );
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_precision/test_good_prec2.txt
+++ b/tests/golden/test_precision/test_good_prec2.txt
@@ -20,16 +20,14 @@
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct c_code_str_Context { 
 
-} c_code_str_Context;
 
 // hoge(
 //     n : size,
 //     x : f32[n]  @DRAM,
 //     y : f32[n]  @DRAM
 // )
-void hoge( c_code_str_Context *ctxt, int_fast32_t n, const float* x, const float* y );
+void hoge( void *ctxt, int_fast32_t n, const float* x, const float* y );
 
 
 
@@ -52,7 +50,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     y : f32[m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, const float* x, const float* y, float* r );
+static void dot( void *ctxt, int_fast32_t m, const float* x, const float* y, float* r );
 
 // dot(
 //     m : size,
@@ -60,7 +58,7 @@ static void dot( c_code_str_Context *ctxt, int_fast32_t m, const float* x, const
 //     y : f32[m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, const float* x, const float* y, float* r ) {
+static void dot( void *ctxt, int_fast32_t m, const float* x, const float* y, float* r ) {
 *r = 0.0;
 for (int i = 0; i < m; i++) {
   *r += x[(i) * (1)] * y[(i) * (1)];
@@ -72,7 +70,7 @@ for (int i = 0; i < m; i++) {
 //     x : f32[n]  @DRAM,
 //     y : f32[n]  @DRAM
 // )
-void hoge( c_code_str_Context *ctxt, int_fast32_t n, const float* x, const float* y ) {
+void hoge( void *ctxt, int_fast32_t n, const float* x, const float* y ) {
 float xy;
 dot(ctxt,n,x,y,&xy);
 }

--- a/tests/golden/test_precision/test_good_prec2.txt
+++ b/tests/golden/test_precision/test_good_prec2.txt
@@ -29,7 +29,7 @@ typedef struct c_code_str_Context {
 //     x : f32[n]  @DRAM,
 //     y : f32[n]  @DRAM
 // )
-void hoge( c_code_str_Context *ctxt, int_fast32_t n, float* x, float* y );
+void hoge( c_code_str_Context *ctxt, int_fast32_t n, const float* x, const float* y );
 
 
 
@@ -52,7 +52,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     y : f32[m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, float* x, float* y, float* r );
+static void dot( c_code_str_Context *ctxt, int_fast32_t m, const float* x, const float* y, float* r );
 
 // dot(
 //     m : size,
@@ -60,7 +60,7 @@ static void dot( c_code_str_Context *ctxt, int_fast32_t m, float* x, float* y, f
 //     y : f32[m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, float* x, float* y, float* r ) {
+static void dot( c_code_str_Context *ctxt, int_fast32_t m, const float* x, const float* y, float* r ) {
 *r = 0.0;
 for (int i = 0; i < m; i++) {
   *r += x[(i) * (1)] * y[(i) * (1)];
@@ -72,7 +72,7 @@ for (int i = 0; i < m; i++) {
 //     x : f32[n]  @DRAM,
 //     y : f32[n]  @DRAM
 // )
-void hoge( c_code_str_Context *ctxt, int_fast32_t n, float* x, float* y ) {
+void hoge( c_code_str_Context *ctxt, int_fast32_t n, const float* x, const float* y ) {
 float xy;
 dot(ctxt,n,x,y,&xy);
 }

--- a/tests/golden/test_schedules/test_expand_dim3.txt
+++ b/tests/golden/test_schedules/test_expand_dim3.txt
@@ -31,14 +31,6 @@ void foo( void *ctxt, int_fast32_t n, int_fast32_t m, int8_t* x );
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_schedules/test_expand_dim3.txt
+++ b/tests/golden/test_schedules/test_expand_dim3.txt
@@ -20,16 +20,14 @@
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct c_code_str_Context { 
 
-} c_code_str_Context;
 
 // foo(
 //     n : size,
 //     m : size,
 //     x : i8  @DRAM
 // )
-void foo( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, int8_t* x );
+void foo( void *ctxt, int_fast32_t n, int_fast32_t m, int8_t* x );
 
 
 
@@ -52,7 +50,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     m : size,
 //     x : i8  @DRAM
 // )
-void foo( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, int8_t* x ) {
+void foo( void *ctxt, int_fast32_t n, int_fast32_t m, int8_t* x ) {
 for (int i = 0; i < n; i++) {
   for (int j = 0; j < m; j++) {
     ; // NO-OP

--- a/tests/golden/test_window/test_normalize.txt
+++ b/tests/golden/test_window/test_normalize.txt
@@ -35,14 +35,6 @@ void proj( void *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const flo
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_window/test_normalize.txt
+++ b/tests/golden/test_window/test_normalize.txt
@@ -20,9 +20,7 @@
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct c_code_str_Context { 
 
-} c_code_str_Context;
 struct exo_win_1f32c{
     const float * const data;
     const int_fast32_t strides[1];
@@ -33,7 +31,7 @@ struct exo_win_1f32c{
 //     x : f32[n,m]  @DRAM,
 //     y : f32[m,n]  @DRAM
 // )
-void proj( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const float* y );
+void proj( void *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const float* y );
 
 
 
@@ -56,7 +54,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     y : [f32][m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32c x, struct exo_win_1f32c y, float* r );
+static void dot( void *ctxt, int_fast32_t m, struct exo_win_1f32c x, struct exo_win_1f32c y, float* r );
 
 // dot(
 //     m : size,
@@ -64,7 +62,7 @@ static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32c 
 //     y : [f32][m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32c x, struct exo_win_1f32c y, float* r ) {
+static void dot( void *ctxt, int_fast32_t m, struct exo_win_1f32c x, struct exo_win_1f32c y, float* r ) {
 *r = 0.0;
 for (int i = 0; i < m; i++) {
   *r += x.data[(i) * (x.strides[0])] * y.data[(i) * (y.strides[0])];
@@ -77,7 +75,7 @@ for (int i = 0; i < m; i++) {
 //     x : f32[n,m]  @DRAM,
 //     y : f32[m,n]  @DRAM
 // )
-void proj( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const float* y ) {
+void proj( void *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const float* y ) {
 EXO_ASSUME(n > 4);
 EXO_ASSUME(m > 4);
 float xy;

--- a/tests/golden/test_window/test_normalize.txt
+++ b/tests/golden/test_window/test_normalize.txt
@@ -23,9 +23,9 @@
 typedef struct c_code_str_Context { 
 
 } c_code_str_Context;
-struct exo_win_1f32{
-    float *data;
-    int_fast32_t strides[1];
+struct exo_win_1f32c{
+    const float * const data;
+    const int_fast32_t strides[1];
 };
 // proj(
 //     n : size,
@@ -56,7 +56,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     y : [f32][m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32 x, struct exo_win_1f32 y, float* r );
+static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32c x, struct exo_win_1f32c y, float* r );
 
 // dot(
 //     m : size,
@@ -64,7 +64,7 @@ static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32 x
 //     y : [f32][m]  @DRAM,
 //     r : f32  @DRAM
 // )
-static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32 x, struct exo_win_1f32 y, float* r ) {
+static void dot( c_code_str_Context *ctxt, int_fast32_t m, struct exo_win_1f32c x, struct exo_win_1f32c y, float* r ) {
 *r = 0.0;
 for (int i = 0; i < m; i++) {
   *r += x.data[(i) * (x.strides[0])] * y.data[(i) * (y.strides[0])];
@@ -82,7 +82,7 @@ EXO_ASSUME(n > 4);
 EXO_ASSUME(m > 4);
 float xy;
 float y2;
-dot(ctxt,m,(struct exo_win_1f32){ (float*)&x[(1) * (m) + (0) * (1)], { 1 } },(struct exo_win_1f32){ (float*)&y[(0) * (n) + (2) * (1)], { n } },&xy);
-dot(ctxt,m,(struct exo_win_1f32){ (float*)&y[(0) * (n) + (3) * (1)], { n } },(struct exo_win_1f32){ (float*)&y[(0) * (n) + (3) * (1)], { n } },&y2);
+dot(ctxt,m,(struct exo_win_1f32c){ &x[(1) * (m) + (0) * (1)], { 1 } },(struct exo_win_1f32c){ &y[(0) * (n) + (2) * (1)], { n } },&xy);
+dot(ctxt,m,(struct exo_win_1f32c){ &y[(0) * (n) + (3) * (1)], { n } },(struct exo_win_1f32c){ &y[(0) * (n) + (3) * (1)], { n } },&y2);
 }
 

--- a/tests/golden/test_window/test_normalize.txt
+++ b/tests/golden/test_window/test_normalize.txt
@@ -33,7 +33,7 @@ struct exo_win_1f32{
 //     x : f32[n,m]  @DRAM,
 //     y : f32[m,n]  @DRAM
 // )
-void proj( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, float* x, float* y );
+void proj( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const float* y );
 
 
 
@@ -77,7 +77,7 @@ for (int i = 0; i < m; i++) {
 //     x : f32[n,m]  @DRAM,
 //     y : f32[m,n]  @DRAM
 // )
-void proj( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, float* x, float* y ) {
+void proj( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x, const float* y ) {
 EXO_ASSUME(n > 4);
 EXO_ASSUME(m > 4);
 float xy;

--- a/tests/golden/test_window/test_stride_assert.txt
+++ b/tests/golden/test_window/test_stride_assert.txt
@@ -20,9 +20,7 @@
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct c_code_str_Context { 
 
-} c_code_str_Context;
 struct exo_win_2i8{
     int8_t * const data;
     const int_fast32_t strides[2];
@@ -37,7 +35,7 @@ struct exo_win_2i8c{
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void stride_assert( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst );
+void stride_assert( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst );
 
 
 
@@ -61,7 +59,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void stride_assert( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
+void stride_assert( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
 EXO_ASSUME(n <= 16);
 EXO_ASSUME(m <= 16);
 EXO_ASSUME(src.strides[1] == 1);

--- a/tests/golden/test_window/test_stride_assert.txt
+++ b/tests/golden/test_window/test_stride_assert.txt
@@ -24,8 +24,12 @@ typedef struct c_code_str_Context {
 
 } c_code_str_Context;
 struct exo_win_2i8{
-    int8_t *data;
-    int_fast32_t strides[2];
+    int8_t * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_2i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[2];
 };
 // stride_assert(
 //     n : size,
@@ -33,7 +37,7 @@ struct exo_win_2i8{
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void stride_assert( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8 src, struct exo_win_2i8 dst );
+void stride_assert( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst );
 
 
 
@@ -57,7 +61,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void stride_assert( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8 src, struct exo_win_2i8 dst ) {
+void stride_assert( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
 EXO_ASSUME(n <= 16);
 EXO_ASSUME(m <= 16);
 EXO_ASSUME(src.strides[1] == 1);

--- a/tests/golden/test_window/test_stride_assert.txt
+++ b/tests/golden/test_window/test_stride_assert.txt
@@ -39,14 +39,6 @@ void stride_assert( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_window/test_window.txt
+++ b/tests/golden/test_window/test_window.txt
@@ -20,9 +20,7 @@
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct c_code_str_Context { 
 
-} c_code_str_Context;
 struct exo_win_2i8{
     int8_t * const data;
     const int_fast32_t strides[2];
@@ -37,7 +35,7 @@ struct exo_win_2i8c{
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void window( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst );
+void window( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst );
 
 
 
@@ -61,7 +59,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void window( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
+void window( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
 EXO_ASSUME(n <= 16);
 EXO_ASSUME(m <= 16);
 for (int i = 0; i < n; i++) {

--- a/tests/golden/test_window/test_window.txt
+++ b/tests/golden/test_window/test_window.txt
@@ -39,14 +39,6 @@ void window( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_window/test_window.txt
+++ b/tests/golden/test_window/test_window.txt
@@ -24,8 +24,12 @@ typedef struct c_code_str_Context {
 
 } c_code_str_Context;
 struct exo_win_2i8{
-    int8_t *data;
-    int_fast32_t strides[2];
+    int8_t * const data;
+    const int_fast32_t strides[2];
+};
+struct exo_win_2i8c{
+    const int8_t * const data;
+    const int_fast32_t strides[2];
 };
 // window(
 //     n : size,
@@ -33,7 +37,7 @@ struct exo_win_2i8{
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void window( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8 src, struct exo_win_2i8 dst );
+void window( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst );
 
 
 
@@ -57,7 +61,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     src : [i8][n,m]  @DRAM,
 //     dst : [i8][n,16]  @DRAM
 // )
-void window( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8 src, struct exo_win_2i8 dst ) {
+void window( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
 EXO_ASSUME(n <= 16);
 EXO_ASSUME(m <= 16);
 for (int i = 0; i < n; i++) {

--- a/tests/golden/test_window/test_window_stmt.txt
+++ b/tests/golden/test_window/test_window_stmt.txt
@@ -32,7 +32,7 @@ struct exo_win_1f32{
 //     m : size,
 //     x : f32[n,m]  @DRAM
 // )
-void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, float* x );
+void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x );
 
 
 
@@ -55,7 +55,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     m : size,
 //     x : f32[n,m]  @DRAM
 // )
-void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, float* x ) {
+void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x ) {
 struct exo_win_1f32 y = (struct exo_win_1f32){ (float*)&x[(0) * (m) + (0) * (1)], { m } };
 float *z = malloc(n * sizeof(*z));
 for (int i = 0; i < n; i++) {

--- a/tests/golden/test_window/test_window_stmt.txt
+++ b/tests/golden/test_window/test_window_stmt.txt
@@ -34,14 +34,6 @@ void window_stmt( void *ctxt, int_fast32_t n, int_fast32_t m, const float* x );
 
 
 
-static int _floor_div(int num, int quot) {
-  int off = (num>=0)? 0 : quot-1;
-  return (num-off)/quot;
-}
-
-static int8_t _clamp_32to8(int32_t x) {
-  return (x < -128)? -128 : ((x > 127)? 127 : x);
-}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/golden/test_window/test_window_stmt.txt
+++ b/tests/golden/test_window/test_window_stmt.txt
@@ -20,9 +20,7 @@
 #  define EXO_ASSUME(expr) ((void)(expr))
 #endif
 
-typedef struct c_code_str_Context { 
 
-} c_code_str_Context;
 struct exo_win_1f32c{
     const float * const data;
     const int_fast32_t strides[1];
@@ -32,7 +30,7 @@ struct exo_win_1f32c{
 //     m : size,
 //     x : f32[n,m]  @DRAM
 // )
-void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x );
+void window_stmt( void *ctxt, int_fast32_t n, int_fast32_t m, const float* x );
 
 
 
@@ -55,7 +53,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     m : size,
 //     x : f32[n,m]  @DRAM
 // )
-void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x ) {
+void window_stmt( void *ctxt, int_fast32_t n, int_fast32_t m, const float* x ) {
 struct exo_win_1f32c y = (struct exo_win_1f32c){ &x[(0) * (m) + (0) * (1)], { m } };
 float *z = malloc(n * sizeof(*z));
 for (int i = 0; i < n; i++) {

--- a/tests/golden/test_window/test_window_stmt.txt
+++ b/tests/golden/test_window/test_window_stmt.txt
@@ -23,9 +23,9 @@
 typedef struct c_code_str_Context { 
 
 } c_code_str_Context;
-struct exo_win_1f32{
-    float *data;
-    int_fast32_t strides[1];
+struct exo_win_1f32c{
+    const float * const data;
+    const int_fast32_t strides[1];
 };
 // window_stmt(
 //     n : size,
@@ -56,7 +56,7 @@ static int8_t _clamp_32to8(int32_t x) {
 //     x : f32[n,m]  @DRAM
 // )
 void window_stmt( c_code_str_Context *ctxt, int_fast32_t n, int_fast32_t m, const float* x ) {
-struct exo_win_1f32 y = (struct exo_win_1f32){ (float*)&x[(0) * (m) + (0) * (1)], { m } };
+struct exo_win_1f32c y = (struct exo_win_1f32c){ &x[(0) * (m) + (0) * (1)], { m } };
 float *z = malloc(n * sizeof(*z));
 for (int i = 0; i < n; i++) {
   z[(i) * (1)] = y.data[(i) * (y.strides[0])];


### PR DESCRIPTION
### Add `const` to function signatures

When a function does not write or accumulate to a parameter it's passed, it should tell the C compiler about this by declaring it `const`. In some cases that can promote inlining or better codegen and definitely improves the ergonomics of _using_ exo functions by allowing callers to declare their local variables const in the first place. It also plays nicer with C's type system generally.

### Use `void` instead of an empty struct

This prevents an actual ABI issue whereby a C compiler is allowed to give such a struct a size of 0, but C++ must give it a size of 1.

Fixes #95 

### Only generate `_floor_div` and `_clamp_32to8` when needed.

Self-explanatory. Also uses `exo_` prefixes since leading underscores are generally sketchy in C.