### PR TITLE
Stop copying whole trees in scheduling passes

### DIFF
--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -515,7 +515,7 @@ def lift_to_eff_expr(e):
 class LoopIR_Rewrite:
     def __init__(self, proc):
         self.orig_proc = proc
-        self.proc = self.map_proc(proc)
+        self.proc = self.apply_proc(proc)
 
     def result(self):
         return self.proc

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -476,133 +476,274 @@ def lift_to_eff_expr(e):
 
 
 class LoopIR_Rewrite:
-    def __init__(self, proc, instr=None, *args, **kwargs):
+    def __init__(self, proc):
         self.orig_proc = proc
-
-        args = [self.map_fnarg(a) for a in self.orig_proc.args]
-        preds = [self.map_e(p) for p in self.orig_proc.preds]
-        preds = [p for p in preds
-                 if not (isinstance(p, LoopIR.Const) and p.val)]
-        body = self.map_stmts(self.orig_proc.body)
-
-        eff = self.map_eff(self.orig_proc.eff)
-
-        self.proc = LoopIR.proc(name=self.orig_proc.name,
-                                args=args,
-                                preds=preds,
-                                body=body,
-                                instr=instr,
-                                eff=eff,
-                                srcinfo=self.orig_proc.srcinfo)
+        self.proc = self.map_proc(proc)
 
     def result(self):
         return self.proc
 
+    def map_proc(self, p):
+        new_args = self._map_list(self.map_fnarg, p.args)
+        new_preds = self.map_exprs(p.preds)
+        new_body = self.map_stmts(p.body)
+        new_eff = self.map_eff(p.eff)
+
+        if any((new_args is not None, new_preds is not None, new_body is not None,
+                new_eff)):
+            new_preds = new_preds or p.preds
+            new_preds = [p for p in new_preds if
+                         not (isinstance(p, LoopIR.Const) and p.val)]
+            return p.update(
+                args=new_args or p.args,
+                preds=new_preds,
+                body=new_body or p.body,
+                eff=new_eff or p.eff,
+            )
+
+        return None
+
     def map_fnarg(self, a):
-        return LoopIR.fnarg(a.name, self.map_t(a.type), a.mem, a.srcinfo)
+        if t := self.map_t(a.type):
+            return a.update(type=t)
+        else:
+            return a
+
+    def _map_list(self, fn, nodes):
+        new_stmts = []
+        needs_update = False
+
+        for s in nodes:
+            s2 = fn(s)
+            if s2 is None:
+                new_stmts.append(s)
+            else:
+                needs_update = True
+                if isinstance(s2, list):
+                    new_stmts.extend(s2)
+                else:
+                    new_stmts.append(s2)
+
+        if not needs_update:
+            return None
+
+        return new_stmts
 
     def map_stmts(self, stmts):
-        return [s for b in stmts
-                for s in self.map_s(b)]
+        return self._map_list(self.map_s, stmts)
+
+    def map_exprs(self, exprs):
+        return self._map_list(self.map_e, exprs)
 
     def map_s(self, s):
-        styp = type(s)
-        if styp is LoopIR.Assign or styp is LoopIR.Reduce:
-            return [styp(s.name, self.map_t(s.type), s.cast,
-                         [self.map_e(a) for a in s.idx],
-                         self.map_e(s.rhs), self.map_eff(s.eff), s.srcinfo)]
-        elif styp is LoopIR.WriteConfig:
-            return [LoopIR.WriteConfig(s.config, s.field, self.map_e(s.rhs),
-                                       self.map_eff(s.eff), s.srcinfo)]
-        elif styp is LoopIR.WindowStmt:
-            return [LoopIR.WindowStmt(s.lhs, self.map_e(s.rhs),
-                                      self.map_eff(s.eff), s.srcinfo)]
-        elif styp is LoopIR.If:
-            return [LoopIR.If(self.map_e(s.cond), self.map_stmts(s.body),
-                              self.map_stmts(s.orelse),
-                              self.map_eff(s.eff), s.srcinfo)]
-        elif styp is LoopIR.Seq:
-            return [LoopIR.Seq(s.iter, self.map_e(s.hi),
-                               self.map_stmts(s.body),
-                               self.map_eff(s.eff), s.srcinfo)]
-        elif styp is LoopIR.Call:
-            return [LoopIR.Call(s.f, [self.map_e(a) for a in s.args],
-                                self.map_eff(s.eff), s.srcinfo)]
-        elif styp is LoopIR.Alloc:
-            return [LoopIR.Alloc(s.name, self.map_t(s.type), s.mem,
-                                 self.map_eff(s.eff), s.srcinfo)]
+        if isinstance(s, (LoopIR.Assign, LoopIR.Reduce)):
+            new_type = self.map_t(s.type)
+            new_idx = self.map_exprs(s.idx)
+            new_rhs = self.map_e(s.rhs)
+            new_eff = self.map_eff(s.eff)
+            if any((new_type, new_idx is not None, new_rhs, new_eff)):
+                return [s.update(
+                    type=new_type or s.type,
+                    idx=new_idx or s.idx,
+                    rhs=new_rhs or s.rhs,
+                    eff=new_eff or s.eff
+                )]
+        elif isinstance(s, (LoopIR.WriteConfig, LoopIR.WindowStmt)):
+            new_rhs = self.map_e(s.rhs)
+            new_eff = self.map_eff(s.eff)
+            if any((new_rhs, new_eff)):
+                return [s.update(
+                    rhs=new_rhs or s.rhs,
+                    eff=new_eff or s.eff
+                )]
+        elif isinstance(s, LoopIR.If):
+            new_cond = self.map_e(s.cond)
+            new_body = self.map_stmts(s.body)
+            new_orelse = self.map_stmts(s.orelse)
+            new_eff = self.map_eff(s.eff)
+            if any((new_cond, new_body is not None, new_orelse is not None, new_eff)):
+                return [s.update(
+                    cond=new_cond or s.cond,
+                    body=new_body or s.body,
+                    orelse=new_orelse or s.orelse,
+                    eff=new_eff or s.eff
+                )]
+        elif isinstance(s, LoopIR.Seq):
+            new_hi = self.map_e(s.hi)
+            new_body = self.map_stmts(s.body)
+            new_eff = self.map_eff(s.eff)
+            if any((new_hi, new_body is not None, new_eff)):
+                return [s.update(
+                    hi=new_hi or s.hi,
+                    body=new_body or s.body,
+                    eff=new_eff or s.eff
+                )]
+        elif isinstance(s, LoopIR.Call):
+            new_args = self.map_exprs(s.args)
+            new_eff = self.map_eff(s.eff)
+            if any((new_args is not None, new_eff)):
+                return [s.update(
+                    args=new_args or s.args,
+                    eff=new_eff or s.eff
+                )]
+        elif isinstance(s, LoopIR.Alloc):
+            new_type = self.map_t(s.type)
+            new_eff = self.map_eff(s.eff)
+            if any((new_type, new_eff)):
+                return [s.update(
+                    type=new_type or s.type,
+                    eff=new_eff or s.eff
+                )]
+        elif isinstance(s, LoopIR.Pass):
+            return None
         else:
-            return [s]
+            raise NotImplementedError(f'bad case {type(s)}')
+        return None
 
     def map_e(self, e):
-        etyp = type(e)
-        if etyp is LoopIR.Read:
-            return LoopIR.Read(e.name, [self.map_e(a) for a in e.idx],
-                               self.map_t(e.type), e.srcinfo)
-        elif etyp is LoopIR.BinOp:
-            return LoopIR.BinOp(e.op, self.map_e(e.lhs), self.map_e(e.rhs),
-                                self.map_t(e.type), e.srcinfo)
-        elif etyp is LoopIR.BuiltIn:
-            return LoopIR.BuiltIn(e.f, [self.map_e(a) for a in e.args],
-                                  self.map_t(e.type), e.srcinfo)
-        elif etyp is LoopIR.USub:
-            return LoopIR.USub(self.map_e(e.arg), self.map_t(e.type), e.srcinfo)
-        elif etyp is LoopIR.WindowExpr:
-            return LoopIR.WindowExpr(e.name,
-                                     [self.map_w_access(w) for w in e.idx],
-                                     self.map_t(e.type), e.srcinfo)
-        elif etyp is LoopIR.ReadConfig:
-            return LoopIR.ReadConfig(e.config, e.field,
-                                     self.map_t(e.type), e.srcinfo)
+        if isinstance(e, LoopIR.Read):
+            new_type = self.map_t(e.type)
+            new_idx = self.map_exprs(e.idx)
+            if any((new_type, new_idx is not None)):
+                return e.update(
+                    idx=new_idx or e.idx,
+                    type=new_type or e.type,
+                )
+        elif isinstance(e, LoopIR.BinOp):
+            new_lhs = self.map_e(e.lhs)
+            new_rhs = self.map_e(e.rhs)
+            new_type = self.map_t(e.type)
+            if any((new_lhs, new_rhs, new_type)):
+                return e.update(
+                    lhs=new_lhs or e.lhs,
+                    rhs=new_rhs or e.rhs,
+                    type=new_type or e.type,
+                )
+        elif isinstance(e, LoopIR.BuiltIn):
+            new_type = self.map_t(e.type)
+            new_args = self.map_exprs(e.args)
+            if any((new_type, new_args is not None)):
+                return e.update(
+                    args=new_args or e.args,
+                    type=new_type or e.type,
+                )
+        elif isinstance(e, LoopIR.USub):
+            new_arg = self.map_e(e.arg)
+            new_type = self.map_t(e.type)
+            if any((new_arg, new_type)):
+                return e.update(
+                    arg=new_arg or e.arg,
+                    type=new_type or e.type,
+                )
+        elif isinstance(e, LoopIR.WindowExpr):
+            new_idx = self._map_list(self.map_w_access, e.idx)
+            new_type = self.map_t(e.type)
+            if any((new_idx is not None, new_type)):
+                return e.update(
+                    idx=new_idx or e.idx,
+                    type=new_type or e.type,
+                )
+        elif isinstance(e, LoopIR.ReadConfig):
+            if new_type := self.map_t(e.type):
+                return e.update(type=new_type or e.type)
+        elif isinstance(e, (LoopIR.Const, LoopIR.StrideExpr)):
+            return None
         else:
-            # constant case cannot have variable-size tensor type
-            # stride expr case has stride type
-            return e
+            raise NotImplementedError(f'bad case {type(s)}')
+        return None
 
     def map_w_access(self, w):
         if isinstance(w, LoopIR.Interval):
-            return LoopIR.Interval(self.map_e(w.lo),
-                                   self.map_e(w.hi), w.srcinfo)
+            new_lo = self.map_e(w.lo)
+            new_hi = self.map_e(w.hi)
+            if new_lo or new_hi:
+                return w.update(
+                    lo=new_lo or w.lo,
+                    hi=new_hi or w.hi,
+                )
         else:
-            return LoopIR.Point(self.map_e(w.pt), w.srcinfo)
+            if new_pt := self.map_e(w.pt):
+                return w.update(pt=new_pt or w.pt)
+        return None
 
     def map_t(self, t):
-        ttyp = type(t)
-        if ttyp is T.Tensor:
-            return T.Tensor([self.map_e(r) for r in t.hi],
-                            t.is_window, self.map_t(t.type))
-        elif ttyp is T.Window:
-            return T.Window(self.map_t(t.src_type), self.map_t(t.as_tensor),
-                            t.src_buf,
-                            [self.map_w_access(w) for w in t.idx])
-        else:
-            return t
+        if isinstance(t, T.Tensor):
+            new_hi = self.map_exprs(t.hi)
+            new_type = self.map_t(t.type)
+            if (new_hi is not None) or new_type:
+                return t.update(
+                    hi=new_hi or t.hi,
+                    type=new_type or t.type
+                )
+        elif isinstance(t, T.Window):
+            new_src_type = self.map_t(t.src_type)
+            new_as_tensor = self.map_t(t.as_tensor)
+            new_idx = self._map_list(self.map_w_access, t.idx)
+            if new_src_type or new_as_tensor or (new_idx is not None):
+                return t.update(
+                    src_type=new_src_type or t.src_type,
+                    as_tensor=new_as_tensor or t.as_tensor,
+                    idx=new_idx or t.idx,
+                )
+        return None
 
     def map_eff(self, eff):
         if eff is None:
             return eff
-        return eff.update(
-            reads=[self.map_eff_es(es) for es in eff.reads],
-            writes=[self.map_eff_es(es) for es in eff.writes],
-            reduces=[self.map_eff_es(es) for es in eff.reduces],
-            config_reads=[self.map_eff_ce(ce) for ce in eff.config_reads],
-            config_writes=[self.map_eff_ce(ce) for ce in eff.config_writes],
-        )
+
+        new_reads = self._map_list(self.map_eff_es, eff.reads)
+        new_writes = self._map_list(self.map_eff_es, eff.writes)
+        new_reduces = self._map_list(self.map_eff_es, eff.reduces)
+        new_config_reads = self._map_list(self.map_eff_ce, eff.config_reads)
+        new_config_writes = self._map_list(self.map_eff_ce, eff.config_writes)
+
+        if any((new_reads is not None,
+                new_writes is not None,
+                new_reduces is not None,
+                new_config_reads is not None,
+                new_config_writes is not None)):
+            return eff.update(
+                reads=new_reads or eff.reads,
+                writes=new_writes or eff.writes,
+                reduces=new_reduces or eff.reduces,
+                config_reads=new_config_reads or eff.config_reads,
+                config_writes=new_config_writes or eff.config_writes,
+            )
+
+        return None
 
     def map_eff_es(self, es):
-        return es.update(loc=[self.map_eff_e(i) for i in es.loc],
-                         pred=self.map_eff_e(es.pred) if es.pred else None)
+        new_loc = self._map_list(self.map_eff_e, es.loc)
+        new_pred = self.map_eff_e(es.pred)
+
+        if (new_loc is not None) or new_pred:
+            return es.update(
+                loc=new_loc or es.loc,
+                pred=new_pred or es.pred,
+            )
+
+        return None
 
     def map_eff_ce(self, ce):
-        return ce.update(value=self.map_eff_e(ce.value) if ce.value else None,
-                         pred=self.map_eff_e(ce.pred) if ce.pred else None)
+        new_value = self.map_eff_e(ce.value)
+        new_pred = self.map_eff_e(ce.pred)
+        if new_value or new_pred:
+            return ce.update(
+                value=new_value or ce.value,
+                pred=new_pred or ce.pred,
+            )
 
     def map_eff_e(self, e):
         if isinstance(e, Effects.BinOp):
-            return e.update(lhs=self.map_eff_e(e.lhs),
-                            rhs=self.map_eff_e(e.rhs))
-        else:
-            return e
+            new_lhs = self.map_eff_e(e.lhs)
+            new_rhs = self.map_eff_e(e.rhs)
+            if new_lhs or new_rhs:
+                return e.update(
+                    lhs=new_lhs or e.lhs,
+                    rhs=new_rhs or e.rhs,
+                )
+
+        return None
 
 
 class LoopIR_Do:
@@ -819,92 +960,72 @@ class Alpha_Rename(LoopIR_Rewrite):
 
     def push(self):
         self.env = self.env.new_child()
+
     def pop(self):
         self.env = self.env.parents
 
-    def map_proc(self, proc):
-        args    = [ self.map_fnarg(fa) for fa in proc.args ]
-        preds   = [ self.map_e(e) for e in proc.preds ]
-        body    = self.map_stmts(proc.body)
-        eff     = self.map_eff(proc.eff)
-
-        return LoopIR.proc(proc.name, args, preds, body,
-                           proc.instr, eff, proc.srcinfo)
-
     def map_fnarg(self, fa):
-        nm  = fa.name.copy()
+        nm = fa.name.copy()
         self.env[fa.name] = nm
-        typ = self.map_t(fa.type)
-        return LoopIR.fnarg(nm, typ, fa.mem, fa.srcinfo)
+        return fa.update(
+            name=nm,
+            type=self.map_t(fa.type) or fa.type
+        )
 
     def map_s(self, s):
-        styp = type(s)
-        if styp is LoopIR.Assign or styp is LoopIR.Reduce:
-            nm = self.env[s.name] if s.name in self.env else s.name
-            return [styp( nm, self.map_t(s.type), s.cast,
-                        [ self.map_e(a) for a in s.idx ],
-                         self.map_e(s.rhs), self.map_eff(s.eff), s.srcinfo )]
-        elif styp is LoopIR.WindowStmt:
-            rhs = self.map_e(s.rhs)
+        if isinstance(s, (LoopIR.Assign, LoopIR.Reduce, LoopIR.Alloc)):
+            s2 = super().map_s(s)
+            if new_name := self.env.get(s.name):
+                return [((s2 and s2[0]) or s).update(name=new_name)]
+            else:
+                return s2
+        elif isinstance(s, LoopIR.WindowStmt):
+            rhs = self.map_e(s.rhs) or s.rhs
             lhs = s.lhs.copy()
             self.env[s.lhs] = lhs
-            return [LoopIR.WindowStmt( lhs, rhs,
-                                       self.map_eff(s.eff), s.srcinfo )]
-        elif styp is LoopIR.If:
+            return [s.update(lhs=lhs, rhs=rhs, eff=self.map_eff(s.eff) or s.eff)]
+        elif isinstance(s, LoopIR.If):
             self.push()
             stmts = super().map_s(s)
             self.pop()
             return stmts
+        elif isinstance(s, LoopIR.Seq):
+            hi = self.map_e(s.hi) or s.hi
+            eff = self.map_eff(s.eff) or s.eff
 
-        elif styp is LoopIR.Seq:
-            hi  = self.map_e(s.hi)
-            eff = self.map_eff(s.eff)
             self.push()
             itr = s.iter.copy()
             self.env[s.iter] = itr
-            stmts = [styp( itr, hi, self.map_stmts(s.body),
-                                eff, s.srcinfo )]
+            body = self.map_stmts(s.body) or s.body
             self.pop()
-            return stmts
 
-        elif styp is LoopIR.Alloc:
-            nm = s.name.copy()
-            self.env[s.name] = nm
-            return [LoopIR.Alloc( nm, self.map_t(s.type), s.mem,
-                                  self.map_eff(s.eff), s.srcinfo )]
+            return [s.update(iter=itr, hi=hi, body=body, eff=eff)]
 
         return super().map_s(s)
 
     def map_e(self, e):
-        etyp = type(e)
-        if etyp is LoopIR.Read:
-            nm = self.env[e.name] if e.name in self.env else e.name
-            return LoopIR.Read( nm, [ self.map_e(a) for a in e.idx ],
-                                self.map_t(e.type), e.srcinfo )
-        elif etyp is LoopIR.WindowExpr:
-            nm = self.env[e.name] if e.name in self.env else e.name
-            return LoopIR.WindowExpr(nm,
-                               [self.map_w_access(a) for a in e.idx],
-                               self.map_t(e.type), e.srcinfo)
-
-        elif etyp is LoopIR.StrideExpr:
-            nm = self.env[e.name] if e.name in self.env else e.name
-            return LoopIR.StrideExpr(nm, e.dim, e.type, e.srcinfo)
+        if isinstance(e, (LoopIR.Read, LoopIR.WindowExpr, LoopIR.StrideExpr)):
+            e2 = super().map_e(e)
+            if new_name := self.env.get(e.name):
+                return [(e2 or e).update(name=new_name)]
+            else:
+                return e2
 
         return super().map_e(e)
 
     def map_eff_es(self, es):
         self.push()
+
         names = [nm.copy() for nm in es.names]
         for orig, new in zip(es.names, names):
             self.env[orig] = new
 
-        eset = es.update(
+        eset = super().map_eff_es(es)
+        eset = (eset or es).update(
             buffer=self.env.get(es.buffer, es.buffer),
-            loc=[self.map_eff_e(i) for i in es.loc],
             names=names,
-            pred=self.map_eff_e(es.pred) if es.pred else None,
         )
+
         self.pop()
         return eset
 
@@ -915,17 +1036,13 @@ class Alpha_Rename(LoopIR_Rewrite):
         return super().map_eff_e(e)
 
     def map_t(self, t):
-        ttyp = type(t)
-        if ttyp is T.Window:
-            src_buf = t.src_buf
-            if t.src_buf in self.env:
-                src_buf = self.env[t.src_buf]
+        t2 = super().map_t(t)
 
-            return T.Window( self.map_t(t.src_type), self.map_t(t.as_tensor),
-                             src_buf,
-                             [ self.map_w_access(w) for w in t.idx ] )
+        if isinstance(t, T.Window):
+            if src_buf := self.env.get(t.src_buf):
+                return (t2 or t).update(src_buf=src_buf)
 
-        return super().map_t(t)
+        return t2
 
 
 class SubstArgs(LoopIR_Rewrite):

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1151,14 +1151,17 @@ class SubstArgs(LoopIR_Rewrite):
         return self.nodes
 
     def map_s(self, s):
+        s2 = super().map_s(s)
+        s_new = s2[0] if s2 is not None else s
+
         # this substitution could refer to a read or a window expression
         if isinstance(s, (LoopIR.Assign, LoopIR.Reduce)):
             if s.name in self.env:
                 sym = self.env[s.name]
                 assert isinstance(sym, LoopIR.Read) and len(sym.idx) == 0
-                return self.apply_s(s).update(name=sym.name)
+                return [s_new.update(name=sym.name)]
 
-        return super().map_s(s)
+        return s2
 
     def map_e(self, e):
         # this substitution could refer to a read or a window expression

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1058,12 +1058,18 @@ class Alpha_Rename(LoopIR_Rewrite):
         )
 
     def map_s(self, s):
-        if isinstance(s, (LoopIR.Assign, LoopIR.Reduce, LoopIR.Alloc)):
+        if isinstance(s, (LoopIR.Assign, LoopIR.Reduce)):
             s2 = super().map_s(s)
             if new_name := self.env.get(s.name):
                 return [((s2 and s2[0]) or s).update(name=new_name)]
             else:
                 return s2
+        elif isinstance(s, LoopIR.Alloc):
+            s2 = super().map_s(s)
+            assert s.name not in self.env
+            new_name = s.name.copy()
+            self.env[s.name] = new_name
+            return [((s2 and s2[0]) or s).update(name=new_name)]
         elif isinstance(s, LoopIR.WindowStmt):
             rhs = self.map_e(s.rhs) or s.rhs
             lhs = s.lhs.copy()

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1032,11 +1032,11 @@ class Alpha_Rename(LoopIR_Rewrite):
             assert isinstance(node, list)
             for n in node:
                 if isinstance(n, LoopIR.stmt):
-                    self.node += self.map_s(n)
+                    self.node += self.apply_s(n)
                 elif isinstance(n, LoopIR.expr):
-                    self.node += [self.map_e(n)]
+                    self.node += [self.apply_e(n)]
                 elif isinstance(n, Effects.effect):
-                    self.node += [self.map_eff(n)]
+                    self.node += [self.apply_eff(n)]
                 else:
                     assert False, "expected stmt or expr or effect"
 

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1,9 +1,9 @@
-from collections import ChainMap
-
 import re
+from collections import ChainMap
 from typing import Type
 
 from asdl_adt import ADT, validators
+
 from .builtins import BuiltIn
 from .configs import Config
 from .memory import Memory
@@ -112,13 +112,13 @@ module LoopIR {
                        sym src_buf, w_access *idx )
 
 }""", ext_types={
-    'name':    validators.instance_of(Identifier, convert=True),
-    'sym':     Sym,
-    'effect':  (lambda x: validators.instance_of(Effects.effect)(x)),
-    'mem':     Type[Memory],
+    'name': validators.instance_of(Identifier, convert=True),
+    'sym': Sym,
+    'effect': (lambda x: validators.instance_of(Effects.effect)(x)),
+    'mem': Type[Memory],
     'builtin': BuiltIn,
-    'config':  Config,
-    'binop':   validators.instance_of(Operator, convert=True),
+    'config': Config,
+    'binop': validators.instance_of(Operator, convert=True),
     'srcinfo': SrcInfo,
 }, memoize={'Num', 'F32', 'F64', 'INT8', 'INT32' 'Bool', 'Int', 'Index',
             'Size', 'Stride', 'Error'})
@@ -180,14 +180,14 @@ module UAST {
             | Stride()
             | Tensor( expr *hi, bool is_window, type type )
 } """, ext_types={
-    'name':        validators.instance_of(Identifier, convert=True),
-    'sym':         Sym,
-    'mem':         Type[Memory],
-    'builtin':     BuiltIn,
-    'config':      Config,
+    'name': validators.instance_of(Identifier, convert=True),
+    'sym': Sym,
+    'mem': Type[Memory],
+    'builtin': BuiltIn,
+    'config': Config,
     'loopir_proc': LoopIR.proc,
-    'op':          validators.instance_of(Operator, convert=True),
-    'srcinfo':     SrcInfo,
+    'op': validators.instance_of(Operator, convert=True),
+    'srcinfo': SrcInfo,
 }, memoize={'Num', 'F32', 'F64', 'INT8', 'INT32',
             'Bool', 'Int', 'Size', 'Index', 'Stride'})
 
@@ -221,9 +221,9 @@ module PAST {
             attributes( srcinfo srcinfo )
 
 } """, ext_types={
-    'name':    validators.instance_of(IdentifierOrHole, convert=True),
+    'name': validators.instance_of(IdentifierOrHole, convert=True),
     'builtin': BuiltIn,
-    'op':      validators.instance_of(Operator, convert=True),
+    'op': validators.instance_of(Operator, convert=True),
     'srcinfo': SrcInfo,
 })
 
@@ -265,12 +265,13 @@ module Effects {
                 attributes( type type, srcinfo srcinfo )
 
 } """, {
-    'sym':     Sym,
-    'type':    LoopIR.type,
-    'binop':   validators.instance_of(Operator, convert=True),
-    'config':  Config,
+    'sym': Sym,
+    'type': LoopIR.type,
+    'binop': validators.instance_of(Operator, convert=True),
+    'config': Config,
     'srcinfo': SrcInfo,
 })
+
 
 # --------------------------------------------------------------------------- #
 # Extension methods
@@ -285,13 +286,18 @@ module Effects {
 def shape(t):
     shp = t.hi if isinstance(t, UAST.Tensor) else []
     return shp
+
+
 del shape
+
 
 @extclass(UAST.type)
 def basetype(t):
     if isinstance(t, UAST.Tensor):
         t = t.type
     return t
+
+
 del basetype
 
 
@@ -299,6 +305,8 @@ del basetype
 @extclass(LoopIR.proc)
 def __hash__(self):
     return id(self)
+
+
 del __hash__
 
 
@@ -307,33 +315,33 @@ del __hash__
 # Types
 
 class T:
-    Num     = LoopIR.Num
-    F32     = LoopIR.F32
-    F64     = LoopIR.F64
-    INT8    = LoopIR.INT8
-    INT32   = LoopIR.INT32
-    Bool    = LoopIR.Bool
-    Int     = LoopIR.Int
-    Index   = LoopIR.Index
-    Size    = LoopIR.Size
-    Stride  = LoopIR.Stride
-    Error   = LoopIR.Error
-    Tensor  = LoopIR.Tensor
-    Window  = LoopIR.WindowType
-    type    = LoopIR.type
-    R       = Num()
-    f32     = F32()
-    int8    = INT8()
-    i8      = INT8()
-    int32   = INT32()
-    i32     = INT32()
-    f64     = F64()
-    bool    = Bool()    # note: accessed as T.bool outside this module
-    int     = Int()
-    index   = Index()
-    size    = Size()
-    stride  = Stride()
-    err     = Error()
+    Num = LoopIR.Num
+    F32 = LoopIR.F32
+    F64 = LoopIR.F64
+    INT8 = LoopIR.INT8
+    INT32 = LoopIR.INT32
+    Bool = LoopIR.Bool
+    Int = LoopIR.Int
+    Index = LoopIR.Index
+    Size = LoopIR.Size
+    Stride = LoopIR.Stride
+    Error = LoopIR.Error
+    Tensor = LoopIR.Tensor
+    Window = LoopIR.WindowType
+    type = LoopIR.type
+    R = Num()
+    f32 = F32()
+    int8 = INT8()
+    i8 = INT8()
+    int32 = INT32()
+    i32 = INT32()
+    f64 = F64()
+    bool = Bool()  # note: accessed as T.bool outside this module
+    int = Int()
+    index = Index()
+    size = Size()
+    stride = Stride()
+    err = Error()
 
 
 # --------------------------------------------------------------------------- #
@@ -354,7 +362,10 @@ def shape(t):
         return t.hi
     else:
         return []
+
+
 del shape
+
 
 @extclass(T.Num)
 @extclass(T.F32)
@@ -381,17 +392,24 @@ def ctype(t):
         return "bool"
     elif isinstance(t, (T.Int, T.Index, T.Size, T.Stride)):
         return "int_fast32_t"
+
+
 del ctype
 
 
 @extclass(LoopIR.type)
 def is_real_scalar(t):
     return isinstance(t, (T.Num, T.F32, T.F64, T.INT8, T.INT32))
+
+
 del is_real_scalar
+
 
 @extclass(LoopIR.type)
 def is_tensor_or_window(t):
     return isinstance(t, (T.Tensor, T.Window))
+
+
 del is_tensor_or_window
 
 
@@ -399,27 +417,39 @@ del is_tensor_or_window
 def is_win(t):
     return ((isinstance(t, T.Tensor) and t.is_window) or
             isinstance(t, T.Window))
+
+
 del is_win
 
 
 @extclass(LoopIR.type)
 def is_numeric(t):
     return t.is_real_scalar() or isinstance(t, (T.Tensor, T.Window))
+
+
 del is_numeric
+
 
 @extclass(LoopIR.type)
 def is_bool(t):
     return isinstance(t, (T.Bool))
+
+
 del is_bool
+
 
 @extclass(LoopIR.type)
 def is_indexable(t):
     return isinstance(t, (T.Int, T.Index, T.Size))
+
+
 del is_indexable
+
 
 @extclass(LoopIR.type)
 def is_stridable(t):
     return isinstance(t, (T.Int, T.Stride))
+
 
 @extclass(LoopIR.type)
 def basetype(t):
@@ -430,6 +460,8 @@ def basetype(t):
         return t.type
     else:
         return t
+
+
 del basetype
 
 
@@ -439,6 +471,7 @@ del basetype
 # Install string printing functions on LoopIR, UAST and T
 # This must be imported after those objects are defined to
 # prevent circular inclusion problems
+# TODO: FIX THIS!!!
 from . import LoopIR_pprint
 
 # --------------------------------------------------------------------------- #
@@ -469,6 +502,7 @@ def lift_to_eff_expr(e):
 
     else:
         assert False, "bad case, e is " + str(type(e))
+
 
 # --------------------------------------------------------------------------- #
 # --------------------------------------------------------------------------- #
@@ -791,7 +825,7 @@ class LoopIR_Rewrite:
 
 class LoopIR_Do:
     def __init__(self, proc, *args, **kwargs):
-        self.proc      = proc
+        self.proc = proc
 
         for a in self.proc.args:
             self.do_t(a.type)
@@ -859,7 +893,8 @@ class LoopIR_Do:
             self.do_e(w.hi)
         elif isinstance(w, LoopIR.Point):
             self.do_e(w.pt)
-        else: assert False, "bad case"
+        else:
+            assert False, "bad case"
 
     def do_t(self, t):
         if isinstance(t, T.Tensor):
@@ -898,8 +933,8 @@ class LoopIR_Do:
 class FreeVars(LoopIR_Do):
     def __init__(self, node):
         assert isinstance(node, list)
-        self.env    = ChainMap()
-        self.fv     = set()
+        self.env = ChainMap()
+        self.fv = set()
 
         for n in node:
             if isinstance(n, LoopIR.stmt):
@@ -908,13 +943,15 @@ class FreeVars(LoopIR_Do):
                 self.do_e(n)
             elif isinstance(n, Effects.effect):
                 self.do_eff(n)
-            else: assert False, "expected stmt, expr, or effect"
+            else:
+                assert False, "expected stmt, expr, or effect"
 
     def result(self):
         return self.fv
 
     def push(self):
         self.env = self.env.new_child()
+
     def pop(self):
         self.env = self.env.parents
 
@@ -949,8 +986,8 @@ class FreeVars(LoopIR_Do):
     def do_e(self, e):
         etyp = type(e)
         if (etyp is LoopIR.Read or
-            etyp is LoopIR.WindowExpr or
-            etyp is LoopIR.StrideExpr):
+                etyp is LoopIR.WindowExpr or
+                etyp is LoopIR.StrideExpr):
             if e.name not in self.env:
                 self.fv.add(e.name)
 
@@ -980,10 +1017,11 @@ class FreeVars(LoopIR_Do):
 
         super().do_eff_e(e)
 
+
 class Alpha_Rename(LoopIR_Rewrite):
     def __init__(self, node):
-        self.env    = ChainMap()
-        self.node   = []
+        self.env = ChainMap()
+        self.node = []
 
         if isinstance(node, LoopIR.proc):
             self.node = self.map_proc(node)
@@ -996,7 +1034,8 @@ class Alpha_Rename(LoopIR_Rewrite):
                     self.node += [self.map_e(n)]
                 elif isinstance(n, Effects.effect):
                     self.node += [self.map_eff(n)]
-                else: assert False, "expected stmt or expr or effect"
+                else:
+                    assert False, "expected stmt or expr or effect"
 
     def result(self):
         return self.node
@@ -1095,14 +1134,15 @@ class SubstArgs(LoopIR_Rewrite):
         assert all(isinstance(v, LoopIR.expr) for v in binding.values())
         assert not any(
             isinstance(v, LoopIR.WindowExpr) for v in binding.values())
-        self.env    = binding
-        self.nodes  = []
+        self.env = binding
+        self.nodes = []
         for n in nodes:
             if isinstance(n, LoopIR.stmt):
                 self.nodes += self.map_s(n)
             elif isinstance(n, LoopIR.expr):
                 self.nodes += [self.map_e(n)]
-            else: assert False, "expected stmt or expr"
+            else:
+                assert False, "expected stmt or expr"
 
     def result(self):
         return self.nodes
@@ -1114,9 +1154,9 @@ class SubstArgs(LoopIR_Rewrite):
             if s.name in self.env:
                 e = self.env[s.name]
                 assert isinstance(e, LoopIR.Read) and len(e.idx) == 0
-                return [styp( e.name, self.map_t(s.type), s.cast,
-                            [ self.map_e(a) for a in s.idx ],
-                              self.map_e(s.rhs), s.eff, s.srcinfo )]
+                return [styp(e.name, self.map_t(s.type), s.cast,
+                             [self.map_e(a) for a in s.idx],
+                             self.map_e(s.rhs), s.eff, s.srcinfo)]
 
         return super().map_s(s)
 
@@ -1141,8 +1181,8 @@ class SubstArgs(LoopIR_Rewrite):
                     sub_e = self.env[e.name]
                     assert (isinstance(sub_e, LoopIR.Read) and len(sub_e.idx) == 0)
                     return LoopIR.WindowExpr(sub_e.name,
-                                       [self.map_w_access(a) for a in e.idx],
-                                       self.map_t(e.type), e.srcinfo)
+                                             [self.map_w_access(a) for a in e.idx],
+                                             self.map_t(e.type), e.srcinfo)
 
         elif isinstance(e, LoopIR.StrideExpr):
             if e.name in self.env:
@@ -1167,7 +1207,7 @@ class SubstArgs(LoopIR_Rewrite):
                     sub_e = self.env[e.name]
                     assert sub_e.type.is_indexable()
                     return lift_to_eff_expr(sub_e)
-                else: # Could be config value (e.g. f32)
+                else:  # Could be config value (e.g. f32)
                     sub_e = self.env[e.name]
                     return lift_to_eff_expr(sub_e)
 
@@ -1180,8 +1220,8 @@ class SubstArgs(LoopIR_Rewrite):
             if t.src_buf in self.env:
                 src_buf = self.env[t.src_buf].name
 
-            return T.Window( self.map_t(t.src_type), self.map_t(t.as_tensor),
-                             src_buf,
-                             [ self.map_w_access(w) for w in t.idx ] )
+            return T.Window(self.map_t(t.src_type), self.map_t(t.as_tensor),
+                            src_buf,
+                            [self.map_w_access(w) for w in t.idx])
 
         return super().map_t(t)

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1027,7 +1027,7 @@ class Alpha_Rename(LoopIR_Rewrite):
         self.node = []
 
         if isinstance(node, LoopIR.proc):
-            self.node = self.map_proc(node)
+            self.node = self.apply_proc(node)
         else:
             assert isinstance(node, list)
             for n in node:

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -477,7 +477,7 @@ def lift_to_eff_expr(e):
 
 class LoopIR_Rewrite:
     def __init__(self, proc, instr=None, *args, **kwargs):
-        self.orig_proc  = proc
+        self.orig_proc = proc
 
         args = [self.map_fnarg(a) for a in self.orig_proc.args]
         preds = [self.map_e(p) for p in self.orig_proc.preds]
@@ -485,15 +485,15 @@ class LoopIR_Rewrite:
                  if not (isinstance(p, LoopIR.Const) and p.val)]
         body = self.map_stmts(self.orig_proc.body)
 
-        eff  = self.map_eff(self.orig_proc.eff)
+        eff = self.map_eff(self.orig_proc.eff)
 
-        self.proc = LoopIR.proc(name    = self.orig_proc.name,
-                                args    = args,
-                                preds   = preds,
-                                body    = body,
-                                instr   = instr,
-                                eff     = eff,
-                                srcinfo = self.orig_proc.srcinfo)
+        self.proc = LoopIR.proc(name=self.orig_proc.name,
+                                args=args,
+                                preds=preds,
+                                body=body,
+                                instr=instr,
+                                eff=eff,
+                                srcinfo=self.orig_proc.srcinfo)
 
     def result(self):
         return self.proc
@@ -502,54 +502,54 @@ class LoopIR_Rewrite:
         return LoopIR.fnarg(a.name, self.map_t(a.type), a.mem, a.srcinfo)
 
     def map_stmts(self, stmts):
-        return [ s for b in stmts
-                   for s in self.map_s(b) ]
+        return [s for b in stmts
+                for s in self.map_s(b)]
 
     def map_s(self, s):
         styp = type(s)
         if styp is LoopIR.Assign or styp is LoopIR.Reduce:
-            return [styp( s.name, self.map_t(s.type), s.cast,
-                        [ self.map_e(a) for a in s.idx ],
-                          self.map_e(s.rhs), self.map_eff(s.eff), s.srcinfo )]
+            return [styp(s.name, self.map_t(s.type), s.cast,
+                         [self.map_e(a) for a in s.idx],
+                         self.map_e(s.rhs), self.map_eff(s.eff), s.srcinfo)]
         elif styp is LoopIR.WriteConfig:
-            return [LoopIR.WriteConfig( s.config, s.field, self.map_e(s.rhs),
-                                        self.map_eff(s.eff), s.srcinfo )]
+            return [LoopIR.WriteConfig(s.config, s.field, self.map_e(s.rhs),
+                                       self.map_eff(s.eff), s.srcinfo)]
         elif styp is LoopIR.WindowStmt:
-            return [LoopIR.WindowStmt( s.lhs, self.map_e(s.rhs),
-                                       self.map_eff(s.eff), s.srcinfo )]
+            return [LoopIR.WindowStmt(s.lhs, self.map_e(s.rhs),
+                                      self.map_eff(s.eff), s.srcinfo)]
         elif styp is LoopIR.If:
-            return [LoopIR.If( self.map_e(s.cond), self.map_stmts(s.body),
-                               self.map_stmts(s.orelse),
-                               self.map_eff(s.eff), s.srcinfo )]
+            return [LoopIR.If(self.map_e(s.cond), self.map_stmts(s.body),
+                              self.map_stmts(s.orelse),
+                              self.map_eff(s.eff), s.srcinfo)]
         elif styp is LoopIR.Seq:
-            return [LoopIR.Seq( s.iter, self.map_e(s.hi),
-                                self.map_stmts(s.body),
-                                self.map_eff(s.eff), s.srcinfo )]
+            return [LoopIR.Seq(s.iter, self.map_e(s.hi),
+                               self.map_stmts(s.body),
+                               self.map_eff(s.eff), s.srcinfo)]
         elif styp is LoopIR.Call:
-            return [LoopIR.Call( s.f, [ self.map_e(a) for a in s.args ],
-                                 self.map_eff(s.eff), s.srcinfo )]
+            return [LoopIR.Call(s.f, [self.map_e(a) for a in s.args],
+                                self.map_eff(s.eff), s.srcinfo)]
         elif styp is LoopIR.Alloc:
-            return [LoopIR.Alloc( s.name, self.map_t(s.type), s.mem,
-                                  self.map_eff(s.eff), s.srcinfo )]
+            return [LoopIR.Alloc(s.name, self.map_t(s.type), s.mem,
+                                 self.map_eff(s.eff), s.srcinfo)]
         else:
             return [s]
 
     def map_e(self, e):
-        etyp    = type(e)
+        etyp = type(e)
         if etyp is LoopIR.Read:
-            return LoopIR.Read( e.name, [ self.map_e(a) for a in e.idx ],
-                                self.map_t(e.type), e.srcinfo )
+            return LoopIR.Read(e.name, [self.map_e(a) for a in e.idx],
+                               self.map_t(e.type), e.srcinfo)
         elif etyp is LoopIR.BinOp:
-            return LoopIR.BinOp( e.op, self.map_e(e.lhs), self.map_e(e.rhs),
-                                 self.map_t(e.type), e.srcinfo )
+            return LoopIR.BinOp(e.op, self.map_e(e.lhs), self.map_e(e.rhs),
+                                self.map_t(e.type), e.srcinfo)
         elif etyp is LoopIR.BuiltIn:
-            return LoopIR.BuiltIn( e.f, [ self.map_e(a) for a in e.args ],
-                                   self.map_t(e.type), e.srcinfo )
+            return LoopIR.BuiltIn(e.f, [self.map_e(a) for a in e.args],
+                                  self.map_t(e.type), e.srcinfo)
         elif etyp is LoopIR.USub:
             return LoopIR.USub(self.map_e(e.arg), self.map_t(e.type), e.srcinfo)
         elif etyp is LoopIR.WindowExpr:
             return LoopIR.WindowExpr(e.name,
-                                     [ self.map_w_access(w) for w in e.idx ],
+                                     [self.map_w_access(w) for w in e.idx],
                                      self.map_t(e.type), e.srcinfo)
         elif etyp is LoopIR.ReadConfig:
             return LoopIR.ReadConfig(e.config, e.field,
@@ -569,12 +569,12 @@ class LoopIR_Rewrite:
     def map_t(self, t):
         ttyp = type(t)
         if ttyp is T.Tensor:
-            return T.Tensor( [ self.map_e(r) for r in t.hi ],
-                             t.is_window, self.map_t(t.type) )
+            return T.Tensor([self.map_e(r) for r in t.hi],
+                            t.is_window, self.map_t(t.type))
         elif ttyp is T.Window:
-            return T.Window( self.map_t(t.src_type), self.map_t(t.as_tensor),
-                             t.src_buf,
-                             [ self.map_w_access(w) for w in t.idx ] )
+            return T.Window(self.map_t(t.src_type), self.map_t(t.as_tensor),
+                            t.src_buf,
+                            [self.map_w_access(w) for w in t.idx])
         else:
             return t
 

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1092,7 +1092,7 @@ class Alpha_Rename(LoopIR_Rewrite):
         if isinstance(e, (LoopIR.Read, LoopIR.WindowExpr, LoopIR.StrideExpr)):
             e2 = super().map_e(e)
             if new_name := self.env.get(e.name):
-                return [(e2 or e).update(name=new_name)]
+                return (e2 or e).update(name=new_name)
             else:
                 return e2
 

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1193,7 +1193,7 @@ class SubstArgs(LoopIR_Rewrite):
 
         elif isinstance(e, LoopIR.StrideExpr):
             if e.name in self.env:
-                return e.update(name=self.env[e.name])
+                return e.update(name=self.env[e.name].name)
 
         return super().map_e(e)
 

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -1720,7 +1720,7 @@ class _LiftAlloc(LoopIR_Rewrite):
         assert False
 
     def map_s(self, s):
-        if s is self.alloc_stmt:
+        if isinstance(s, LoopIR.Alloc) and s.name == self.alloc_sym:
             # mark the point we want to lift this alloc-stmt to
             n_up = min(self.n_lifts, len(self.ctrl_ctxt))
             self.lift_site = self.ctrl_ctxt[-n_up]

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -495,25 +495,21 @@ class _Unroll(LoopIR_Rewrite):
     def map_s(self, s):
         if s is self.unroll_loop:
             if not isinstance(s.hi, LoopIR.Const):
-                raise SchedulingError(f"expected loop '{s.iter}' "
-                                      f"to have constant bounds")
-            # if len(s.body) != 1:
-            #    raise SchedulingError(f"expected loop '{s.iter}' "
-            #                          f"to have only one body")
+                raise SchedulingError(
+                    f"expected loop '{s.iter}' to have constant bounds")
+
             hi = s.hi.val
             if hi == 0:
                 return []
 
-            # assert hi > 0
             orig_body = s.body
 
             self.unroll_itr = 0
 
-            body = Alpha_Rename(self.map_stmts(orig_body)).result()
+            body = Alpha_Rename(self.apply_stmts(orig_body)).result()
             for i in range(1, hi):
                 self.unroll_itr = i
-                nxtbody = Alpha_Rename(self.map_stmts(orig_body)).result()
-                body += nxtbody
+                body += Alpha_Rename(self.apply_stmts(orig_body)).result()
 
             return body
 

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -3474,10 +3474,11 @@ class _DoStageMem(LoopIR_Rewrite):
         if self.in_block:
             if isinstance(s, (LoopIR.Assign, LoopIR.Reduce)):
                 if s.name is self.buf_name:
-                    assert len(new_s) == 1
-                    new_s[0] = new_s[0].update(name=self.new_name)
-                    idx = self.rewrite_idx(new_s[0].idx)
-                    new_s[0] = new_s[0].update(idx=idx)
+                    new_s = new_s[0] if new_s is not None else s
+                    new_s = new_s.update(name=self.new_name)
+                    idx = self.rewrite_idx(new_s.idx)
+                    new_s = new_s.update(idx=idx)
+                    return new_s
 
         return new_s
 
@@ -3487,15 +3488,17 @@ class _DoStageMem(LoopIR_Rewrite):
         if self.in_block:
             if isinstance(e, LoopIR.Read):
                 if e.name is self.buf_name:
+                    new_e = new_e or e
                     new_e = new_e.update(name=self.new_name)
 
                     idx = self.rewrite_idx(new_e.idx)
-                    new_e = new_e.update(idx=idx)
+                    return new_e.update(idx=idx)
 
             elif isinstance(e, LoopIR.WindowExpr):
                 if e.name is self.buf_name:
+                    new_e = new_e or e
                     w_idx = self.rewrite_win(new_e.idx)
-                    new_e = new_e.update(
+                    return new_e.update(
                         name=self.new_name,
                         idx=w_idx,
                         type=T.Window(self.new_typ, e.type.as_tensor,

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -617,27 +617,17 @@ class _PartialEval(LoopIR_Rewrite):
         # Validate env:
         for k, v in self.env.items():
             if not arg_types[k].is_indexable() and not arg_types[k].is_bool():
-                raise SchedulingError("cannot partially evaluate "
-                                      "numeric (non-index, non-bool) arguments")
+                raise SchedulingError(
+                    "cannot partially evaluate numeric (non-index, non-bool) arguments")
             if not isinstance(v, int):
-                raise SchedulingError("cannot partially evaluate "
-                                      "to a non-int, non-bool value")
+                raise SchedulingError(
+                    "cannot partially evaluate to a non-int, non-bool value")
 
-        self.orig_proc = proc
-
-        args = [self.map_fnarg(a) for a in proc.args
-                if a.name not in self.env]
-        preds = [self.map_e(p) for p in self.orig_proc.preds]
-        body = self.map_stmts(self.orig_proc.body)
-        eff = self.map_eff(self.orig_proc.eff)
-
-        self.proc = LoopIR.proc(name=self.orig_proc.name,
-                                args=args,
-                                preds=preds,
-                                body=body,
-                                instr=None,
-                                eff=eff,
-                                srcinfo=self.orig_proc.srcinfo)
+        super().__init__(proc)
+        self.proc = self.proc.update(
+            args=[a for a in self.proc.args
+                  if a.name not in arg_vals]
+        )
 
     def map_e(self, e):
         if isinstance(e, LoopIR.Read):

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -2762,14 +2762,17 @@ class _DoDeletePass(LoopIR_Rewrite):
     def map_s(self, s):
         if isinstance(s, LoopIR.Pass):
             return []
+
         elif isinstance(s, LoopIR.Seq):
             body = self.map_stmts(s.body)
-            if not body:
+            if body is None:
+                return None
+            elif body == []:
                 return []
             else:
                 return [s.update(body=body)]
-        else:
-            return super().map_s(s)
+
+        return super().map_s(s)
 
 
 class _DoExtractMethod(LoopIR_Rewrite):

--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -132,8 +132,7 @@ class DoReplace(LoopIR_Rewrite):
             new_args = Unification(subproc, stmts, self.live_vars).result()
 
             # but don't use a different LoopIR.proc for the callsite itself
-            new_call = LoopIR.Call(self.subproc, new_args,
-                                   None, stmts[0].srcinfo)
+            new_call = LoopIR.Call(self.subproc, new_args, None, stmts[0].srcinfo)
 
             return prefix_stmts + [new_call] + suffix_stmts
 

--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -116,7 +116,7 @@ class DoReplace(LoopIR_Rewrite):
         if match_i is None:
             return super().map_stmts(stmts)
         else: # process the match
-            prefix_stmts    = super().map_stmts(stmts[ : match_i])
+            prefix_stmts    = super().apply_stmts(stmts[ : match_i])
             suffix_stmts    = stmts[match_i+n_stmts : ]
             stmts           = stmts[match_i : match_i+n_stmts]
 

--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -4,9 +4,9 @@ import re
 from collections import ChainMap
 
 import pysmt
+from asdl_adt import ADT
 from pysmt import shortcuts as SMT
 
-from asdl_adt import ADT
 from .LoopIR import (LoopIR, T, LoopIR_Rewrite, LoopIR_Do, FreeVars,
                      Alpha_Rename)
 from .LoopIR_dataflow import LoopIR_Dependencies
@@ -25,12 +25,14 @@ def _get_smt_solver():
 def sanitize_str(s):
     return re.sub(r'\W', '_', s)
 
+
 # --------------------------------------------------------------------------- #
 # --------------------------------------------------------------------------- #
 
 class UnificationError(Exception):
-    def __init__(self,msg):
-        self._err_msg   = str(msg)
+    def __init__(self, msg):
+        self._err_msg = str(msg)
+
     def __str__(self):
         return self._err_msg
 
@@ -43,9 +45,9 @@ class DoReplace(LoopIR_Rewrite):
             raise SchedulingError("Not enough statements to match")
         stmt_block = stmt_block[:n_stmts]
 
-        self.subproc        = subproc
-        self.target_block   = stmt_block
-        self.live_vars      = ChainMap()
+        self.subproc = subproc
+        self.target_block = stmt_block
+        self.live_vars = ChainMap()
 
         super().__init__(proc)
         # fix up effects post-hoc
@@ -67,6 +69,7 @@ class DoReplace(LoopIR_Rewrite):
 
     def push(self):
         self.live_vars = self.live_vars.new_child()
+
     def pop(self):
         self.live_vars = self.live_vars.parents
 
@@ -78,12 +81,11 @@ class DoReplace(LoopIR_Rewrite):
         # For all leaf-statements (containing no sub-statements),
         # just return the original statement.  Bind variables when
         # necessary, and then for scoped blocks, manage scope and recursion
-        styp = type(s)
-        if styp is LoopIR.WindowStmt:
+        if isinstance(s, LoopIR.WindowStmt):
             self.live_vars[s.lhs] = s.rhs.type
-        elif styp is LoopIR.Alloc:
+        elif isinstance(s, LoopIR.Alloc):
             self.live_vars[s.name] = s.type
-        elif styp is LoopIR.If:
+        elif isinstance(s, LoopIR.If):
             self.push()
             body = self.map_stmts(s.body)
             self.pop()
@@ -91,54 +93,49 @@ class DoReplace(LoopIR_Rewrite):
             orelse = self.map_stmts(s.orelse)
             self.pop()
 
-            return [LoopIR.If( s.cond, body, orelse, s.eff, s.srcinfo )]
+            if body or orelse:
+                return [s.update(
+                    body=body or s.body,
+                    orelse=orelse or s.orelse
+                )]
 
-        elif styp is LoopIR.Seq:
+        elif isinstance(s, LoopIR.Seq):
             self.push()
             self.live_vars[s.iter] = T.index
             body = self.map_stmts(s.body)
             self.pop()
 
-            return [styp( s.iter, s.hi, body, s.eff, s.srcinfo )]
+            if body:
+                return [s.update(body=body)]
 
-        return [s]
+        return None
 
     def map_stmts(self, stmts):
         # see if we can find the target block in this block
         n_stmts = len(self.target_block)
         match_i = None
-        for i,s in enumerate(stmts):
+        for i, s in enumerate(stmts):
             if s == self.target_block[0]:
-                if stmts[i:i+n_stmts] == self.target_block:
+                if stmts[i:i + n_stmts] == self.target_block:
                     match_i = i
                     break
 
         if match_i is None:
             return super().map_stmts(stmts)
-        else: # process the match
-            prefix_stmts    = super().apply_stmts(stmts[ : match_i])
-            suffix_stmts    = stmts[match_i+n_stmts : ]
-            stmts           = stmts[match_i : match_i+n_stmts]
+        else:  # process the match
+            prefix_stmts = super().apply_stmts(stmts[: match_i])
+            suffix_stmts = stmts[match_i + n_stmts:]
+            stmts = stmts[match_i: match_i + n_stmts]
 
             # prevent name clashes between the statement block and sub-proc
             subproc = Alpha_Rename(self.subproc).result()
-            new_args = Unification(subproc, stmts,
-                                   self.live_vars).result()
+            new_args = Unification(subproc, stmts, self.live_vars).result()
 
             # but don't use a different LoopIR.proc for the callsite itself
             new_call = LoopIR.Call(self.subproc, new_args,
                                    None, stmts[0].srcinfo)
 
             return prefix_stmts + [new_call] + suffix_stmts
-
-    # make this more efficient by not rewriting
-    # most of the sub-trees
-    def map_e(self,e):
-        return e
-    def map_t(self,t):
-        return t
-    def map_eff(self,eff):
-        return eff
 
 
 # --------------------------------------------------------------------------- #
@@ -182,13 +179,15 @@ def _str_uexpr(e, prec=0):
     elif etyp is UEq.Var:
         return str(e.name)
     elif etyp is UEq.Add:
-        s = f"{_str_uexpr(e.lhs,0)} + {_str_uexpr(e.rhs,1)}"
+        s = f"{_str_uexpr(e.lhs, 0)} + {_str_uexpr(e.rhs, 1)}"
         if prec > 0:
             s = f"({s})"
         return s
     elif etyp is UEq.Scale:
-        return f"{e.coeff}*{_str_uexpr(e.e,10)}"
-    else: assert False, "bad case"
+        return f"{e.coeff}*{_str_uexpr(e.e, 10)}"
+    else:
+        assert False, "bad case"
+
 
 @extclass(UEq.Const)
 @extclass(UEq.Var)
@@ -196,22 +195,27 @@ def _str_uexpr(e, prec=0):
 @extclass(UEq.Scale)
 def __str__(self):
     return _str_uexpr(self)
+
+
 del __str__
+
 
 def _str_upred(p, prec=0):
     ptyp = type(p)
     if ptyp is UEq.Eq:
         return f"{p.lhs} == {p.rhs}"
     elif ptyp is UEq.Conj or ptyp is UEq.Disj:
-        op  = ' and ' if UEq.Conj else ' or '
-        s   = op.join([ _str_upred(pp,1) for pp in p.preds ])
+        op = ' and ' if UEq.Conj else ' or '
+        s = op.join([_str_upred(pp, 1) for pp in p.preds])
         if prec > 0:
             s = f"({s})"
         return s
     elif ptyp is UEq.Cases:
-        return (f'cases({p.case_var}) '+
-                ' | '.join([ f"({pred})" for pred in p.cases ]))
-    else: assert False, "bad case"
+        return (f'cases({p.case_var}) ' +
+                ' | '.join([f"({pred})" for pred in p.cases]))
+    else:
+        assert False, "bad case"
+
 
 @extclass(UEq.Conj)
 @extclass(UEq.Cases)
@@ -219,14 +223,19 @@ def _str_upred(p, prec=0):
 @extclass(UEq.Eq)
 def __str__(self):
     return _str_upred(self)
+
+
 del __str__
+
 
 @extclass(UEq.problem)
 def __str__(prob):
-    lines = [ "Holes:   "+', '.join([ str(x) for x in prob.holes ]) ,
-              "Knowns:  "+', '.join([ str(x) for x in prob.knowns ]) ]
-    lines += [ str(p) for p in prob.preds ]
+    lines = ["Holes:   " + ', '.join([str(x) for x in prob.holes]),
+             "Knowns:  " + ', '.join([str(x) for x in prob.knowns])]
+    lines += [str(p) for p in prob.preds]
     return '\n'.join(lines)
+
+
 del __str__
 
 
@@ -274,14 +283,16 @@ def normalize(orig_e):
                 return [], 0
             cs, off = to_nform(e.e)
             return [(e.coeff * c, v) for (c, v) in cs], e.coeff * off
-        else: assert False, "bad case"
+        else:
+            assert False, "bad case"
+
     def from_nform(cs, off):
         e = None
-        for (c,v) in cs:
+        for (c, v) in cs:
             assert c != 0
             t = UEq.Var(v)
-            t = t if c == 1 else UEq.Scale(c,t)
-            e = t if e is None else UEq.Add(e,t)
+            t = t if c == 1 else UEq.Scale(c, t)
+            e = t if e is None else UEq.Add(e, t)
         if e is None:
             return UEq.Const(off)
         elif off == 0:
@@ -292,34 +303,39 @@ def normalize(orig_e):
     cs, off = to_nform(orig_e)
     return from_nform(cs, off)
 
+
 @extclass(UEq.expr)
-def sub(x,y):
-    return UEq.Add(x, UEq.Scale(-1,y))
+def sub(x, y):
+    return UEq.Add(x, UEq.Scale(-1, y))
+
 
 @extclass(UEq.problem)
 def solve(prob):
-    solver      = _get_smt_solver()
+    solver = _get_smt_solver()
 
-    known_list  = prob.knowns
-    known_idx   = { k : i for i,k in enumerate(known_list) }
-    hole_idx    = { k : i for i,k in enumerate(prob.holes) }
-    Nk          = len(known_list)
+    known_list = prob.knowns
+    known_idx = {k: i for i, k in enumerate(known_list)}
+    hole_idx = {k: i for i, k in enumerate(prob.holes)}
+    Nk = len(known_list)
 
-    var_set     = dict()
-    case_set    = dict()
+    var_set = dict()
+    case_set = dict()
+
     def get_var(x):
         if x in var_set:
             return var_set[x]
         else:
-            vec = ([ SMT.Symbol(f"{repr(x)}_{repr(k)}", SMT.INT)
-                     for k in known_list ] +
-                   [ SMT.Symbol(f"{repr(x)}_const", SMT.INT) ])
+            vec = ([SMT.Symbol(f"{repr(x)}_{repr(k)}", SMT.INT)
+                    for k in known_list] +
+                   [SMT.Symbol(f"{repr(x)}_const", SMT.INT)])
             var_set[x] = vec
             return vec
+
     def get_case(x):
         if x not in case_set:
             case_set[x] = SMT.Symbol(f"{repr(x)}", SMT.INT)
         return case_set[x]
+
     # initialize all hole variables, ensuring they are defined
     for x in prob.holes:
         get_var(x)
@@ -372,19 +388,20 @@ def solve(prob):
             case_lo = SMT.GE(case_var, SMT.Int(0))
             case_hi = SMT.LT(case_var, SMT.Int(len(p.cases)))
             return SMT.And(disj, case_lo, case_hi)
-        else: assert False, "bad case"
+        else:
+            assert False, "bad case"
 
-    prob_pred   = SMT.And(*[ lower_p(p) for p in prob.preds ])
+    prob_pred = SMT.And(*[lower_p(p) for p in prob.preds])
     if not solver.is_sat(prob_pred):
         return None
     else:
         solutions = dict()
         for hole_var in prob.holes:
-            x_syms      = get_var(hole_var)
-            x_val_dict  = solver.get_py_values(x_syms)
-            x_vals      = [ x_val_dict[x_sym] for x_sym in x_syms ]
-            expr        = None
-            for xx,v in zip(known_list, x_vals):
+            x_syms = get_var(hole_var)
+            x_val_dict = solver.get_py_values(x_syms)
+            x_vals = [x_val_dict[x_sym] for x_sym in x_syms]
+            expr = None
+            for xx, v in zip(known_list, x_vals):
                 v = int(v)
                 if v == 0:
                     continue
@@ -396,8 +413,8 @@ def solve(prob):
                 expr = term if expr is None else UEq.Add(expr, term)
 
             # constant offset
-            off     = UEq.Const(int(x_vals[-1]))
-            expr    = off if expr is None else UEq.Add(expr, off)
+            off = UEq.Const(int(x_vals[-1]))
+            expr = off if expr is None else UEq.Add(expr, off)
 
             solutions[hole_var] = expr
 
@@ -409,7 +426,6 @@ def solve(prob):
         return solutions
 
 
-
 # --------------------------------------------------------------------------- #
 # --------------------------------------------------------------------------- #
 # Unification compiler pass
@@ -417,12 +433,12 @@ def solve(prob):
 
 class _Find_Mod_Div_Symbols(LoopIR_Do):
     def __init__(self, stmts, FV):
-        self.node_to_sym    = dict() # many to one
-        self.tuple_to_sym   = dict() # de-duplicating lookup
-        self.sym_to_node    = dict() # pick a node for each symbol
-        self.FV             = FV
+        self.node_to_sym = dict()  # many to one
+        self.tuple_to_sym = dict()  # de-duplicating lookup
+        self.sym_to_node = dict()  # pick a node for each symbol
+        self.FV = FV
 
-        self.unq_count      = 0
+        self.unq_count = 0
 
         self.do_stmts(stmts)
 
@@ -447,9 +463,9 @@ class _Find_Mod_Div_Symbols(LoopIR_Do):
                 sym = self.tuple_to_sym[tuple_node]
             # or we are encountering it for the first time
             else:
-                opname      = 'mod' if e.op == '%' else 'div'
-                node_name   = sanitize_str(str(e))
-                sym         = Sym(f'{opname}_{self.unq_count}_{node_name}')
+                opname = 'mod' if e.op == '%' else 'div'
+                node_name = sanitize_str(str(e))
+                sym = Sym(f'{opname}_{self.unq_count}_{node_name}')
                 self.unq_count += 1
                 self.tuple_to_sym[tuple_node] = sym
                 self.sym_to_node[sym] = e
@@ -477,41 +493,43 @@ class _Find_Mod_Div_Symbols(LoopIR_Do):
         elif isinstance(e, LoopIR.BinOp):
             return self.tuple_memo(e.op, self.tupleify(e.lhs),
                                    self.tupleify(e.rhs))
-        else: assert False, "Bad case tupleify"
+        else:
+            assert False, "Bad case tupleify"
 
     def do_eff(self, eff):
         return
 
+
 class BufVar:
     def __init__(self, name, typ, use_win=True):
-        self.name           = name
-        self.typ            = typ
-        self.n_dim          = len(typ.shape())
+        self.name = name
+        self.typ = typ
+        self.n_dim = len(typ.shape())
 
-        self.solution_buf   = None
+        self.solution_buf = None
 
-        self.use_win        = use_win
+        self.use_win = use_win
         # `win_dim` is the number of dimensions that are
         # point-accesses in a window expression
         # `n_dim` is the number of dimensions that are
         # interval/slice-accesses in a window expression
         # The sum of the two is the size of whatever buffer is unified against
-        self.win_dim        = None
-        self.cases          = []
-        self.case_var       = None
+        self.win_dim = None
+        self.cases = []
+        self.case_var = None
 
     def set_buf_solution(self, solution_buf):
-        self.solution_buf   = solution_buf
+        self.solution_buf = solution_buf
 
     def set_window_dim(self, win_dim):
         assert win_dim is not None
-        do_setup            = self.win_dim is None
-        self.win_dim        = win_dim
+        do_setup = self.win_dim is None
+        self.win_dim = win_dim
 
         if do_setup:
-            self.cases      = []
-            self.case_var   = Sym(f"{self.name}_which_case")
-            full_dim        = self.n_dim + win_dim
+            self.cases = []
+            self.case_var = Sym(f"{self.name}_which_case")
+            full_dim = self.n_dim + win_dim
 
             for case_id, pt_idxs in enumerate(
                     itertools.combinations(range(0, full_dim), win_dim)):
@@ -538,16 +556,16 @@ class BufVar:
         for c in self.cases:
             intervals = [i for i in c if not isinstance(i, Sym)]
             assert len(intervals) == self.n_dim
-            for (lo,hi),sz in zip(intervals, self.typ.shape()):
-                diff    = UEq.Add( UEq.Var(hi), UEq.Scale(-1, UEq.Var(lo)) )
-                results += [UEq.Eq( diff, UObj.to_ueq(sz) )]
+            for (lo, hi), sz in zip(intervals, self.typ.shape()):
+                diff = UEq.Add(UEq.Var(hi), UEq.Scale(-1, UEq.Var(lo)))
+                results += [UEq.Eq(diff, UObj.to_ueq(sz))]
         return results
 
     def all_syms(self):
         if not self.case_var:
             return []
         else:
-            xs = [ self.case_var ]
+            xs = [self.case_var]
             for c in self.cases:
                 for i in c:
                     if isinstance(i, Sym):
@@ -558,22 +576,22 @@ class BufVar:
             return xs
 
     def get_solution(self, UObj, ueq_solutions, srcinfo):
-        buf     = self.solution_buf
+        buf = self.solution_buf
         buf_typ = UObj.FV[buf]
         if not self.case_var:
             return LoopIR.Read(buf, [], buf_typ, srcinfo)
         else:
-            which_case  = ueq_solutions[self.case_var]
-            case        = self.cases[which_case]
+            which_case = ueq_solutions[self.case_var]
+            case = self.cases[which_case]
 
-            def subtract(hi,lo):
+            def subtract(hi, lo):
                 if isinstance(lo, LoopIR.Const) and lo.val == 0:
                     return hi
                 else:
                     return LoopIR.BinOp('-', hi, lo, T.index, hi.srcinfo)
 
-            idx         = []
-            win_shape   = []
+            idx = []
+            win_shape = []
             for w in case:
                 if isinstance(w, Sym):
                     pt = UObj.from_ueq(ueq_solutions[w], srcinfo)
@@ -584,8 +602,8 @@ class BufVar:
                     idx.append(LoopIR.Interval(lo, hi, srcinfo))
                     win_shape.append(subtract(hi, lo))
 
-            as_tensor   = T.Tensor(win_shape, True, buf_typ.type)
-            w_typ       = T.Window(buf_typ, as_tensor, buf, idx)
+            as_tensor = T.Tensor(win_shape, True, buf_typ.type)
+            w_typ = T.Window(buf_typ, as_tensor, buf, idx)
             return LoopIR.WindowExpr(buf, idx, w_typ, srcinfo)
 
 
@@ -595,40 +613,40 @@ class Unification:
         self.stmt_block = stmt_block
 
         # variables for the UEq system
-        #self.holes      = []
-        #self.knowns     = []
+        # self.holes      = []
+        # self.knowns     = []
 
         # set up different kinds of variables before we
         # begin doing the structural matching...
-        #self.arg_syms       = { fa.name : True for fa in subproc.args }
-        self.index_holes    = [ fa.name for fa in subproc.args
-                                        if fa.type.is_indexable() ]
-        self.buf_holes      = { fa.name :
-                                BufVar(fa.name, fa.type, fa.type.is_win())
-                                for fa in subproc.args
-                                if fa.type.is_numeric() }
-        self.bool_holes     = { fa.name : False for fa in subproc.args
-                                                if fa.type == T.bool }
+        # self.arg_syms       = { fa.name : True for fa in subproc.args }
+        self.index_holes = [fa.name for fa in subproc.args
+                            if fa.type.is_indexable()]
+        self.buf_holes = {fa.name:
+                              BufVar(fa.name, fa.type, fa.type.is_win())
+                          for fa in subproc.args
+                          if fa.type.is_numeric()}
+        self.bool_holes = {fa.name: False for fa in subproc.args
+                           if fa.type == T.bool}
 
-        self.stride_holes   = { fa.name : False for fa in subproc.args
-                                                if fa.type == T.stride }
-
+        self.stride_holes = {fa.name: False for fa in subproc.args
+                             if fa.type == T.stride}
 
         # keep track of all buffer names we might need to unify,
         # not just the unknown arguments, but also temporary allocated bufs
         # these variables should ONLY occur on the sub-procedure side
         # of the unification; no BufVars for the original code.
-        self.buf_unknowns   = self.buf_holes.copy()
+        self.buf_unknowns = self.buf_holes.copy()
 
         # get the free variables, and lookup their types
         # as well as expanding the free variable set to
         # account for dependent typing
-        FV_set          = FreeVars(stmt_block).result()
-        self.FV         = dict()
+        FV_set = FreeVars(stmt_block).result()
+        self.FV = dict()
+
         def add_fv(x):
             assert x in live_vars, f"expected FV {x} to be live"
-            typ         = live_vars[x]
-            self.FV[x]  = typ
+            typ = live_vars[x]
+            self.FV[x] = typ
 
             def expand_e(e):
                 if isinstance(e, LoopIR.Read):
@@ -650,20 +668,21 @@ class Unification:
                     else:
                         expand_e(w.pt)
                 add_fv(typ.src_buf)
+
         for x in FV_set:
             add_fv(x)
 
         # block-side buffer types
-        self.bbuf_types     = { x : self.FV[x] for x in self.FV
-                                                if self.FV[x].is_numeric() }
+        self.bbuf_types = {x: self.FV[x] for x in self.FV
+                           if self.FV[x].is_numeric()}
 
-        #self.node_syms  = None
-        #self.sym_nodes  = None
+        # self.node_syms  = None
+        # self.sym_nodes  = None
         self.node_syms, self.sym_nodes = _Find_Mod_Div_Symbols(stmt_block,
-                                                        self.FV).result()
+                                                               self.FV).result()
 
         # substitutions to do of intermediate indexing variables
-        self.idx_subst      = dict()
+        self.idx_subst = dict()
 
         # TODO: Asserts
         # We don't have inequality in EQs IR
@@ -681,15 +700,15 @@ class Unification:
                     f"Cannot perform unification due to an un-unused "
                     f"argument: {nm}")
 
-        holes       = (self.index_holes +
-                       [ x for nm in self.buf_holes
-                           for x in self.buf_holes[nm].all_syms() ])
-        knowns      = ([ nm for nm in self.sym_nodes ]+
-                       [ nm for nm in self.FV if self.FV[nm].is_indexable() ])
-        ueq_prob    = UEq.problem(holes, knowns, self.equations)
+        holes = (self.index_holes +
+                 [x for nm in self.buf_holes
+                  for x in self.buf_holes[nm].all_syms()])
+        knowns = ([nm for nm in self.sym_nodes] +
+                  [nm for nm in self.FV if self.FV[nm].is_indexable()])
+        ueq_prob = UEq.problem(holes, knowns, self.equations)
 
         # solve the problem
-        solutions   = ueq_prob.solve()
+        solutions = ueq_prob.solve()
         if solutions is None:
             raise UnificationError(
                 f"Unification of various index expressions failed")
@@ -713,15 +732,14 @@ class Unification:
                     return self.stride_holes[fa.name]
                 else:
                     raise UnificationError(f"stride argument {fa.name}"
-                                           +" unused")
+                                           + " unused")
             else:
                 assert fa.type.is_numeric()
-                bufvar  = self.buf_holes[fa.name]
+                bufvar = self.buf_holes[fa.name]
                 return bufvar.get_solution(self, solutions,
                                            stmt_block[0].srcinfo)
-        self.new_args   = [ get_arg(fa) for fa in subproc.args ]
 
-
+        self.new_args = [get_arg(fa) for fa in subproc.args]
 
     def err(self):
         raise TypeError("subproc and pattern don't match")
@@ -765,8 +783,10 @@ class Unification:
                 else:
                     name = self.node_syms[id(e)]
                     return UEq.Var(name)
-            else: assert False, f"bad op case: {e.op}"
-        else: assert False, "unexpected affine expression case"
+            else:
+                assert False, f"bad op case: {e.op}"
+        else:
+            assert False, "unexpected affine expression case"
 
     def from_ueq(self, e, srcinfo=null_srcinfo()):
         if isinstance(e, UEq.Var):
@@ -790,7 +810,8 @@ class Unification:
             lhs = LoopIR.Const(e.coeff, T.int, srcinfo)
             rhs = self.from_ueq(e.e, srcinfo)
             return LoopIR.BinOp('*', lhs, rhs, rhs.type, srcinfo)
-        else: assert False, "bad case"
+        else:
+            assert False, "bad case"
 
     # ----------
 
@@ -829,13 +850,14 @@ class Unification:
             return (e0.f == e1.f and
                     all(self.is_exact_e(a0, a1)
                         for a0, a1 in zip(e0.args, e1.args)))
-        else: assert False, "unsupported case"
+        else:
+            assert False, "unsupported case"
 
     # ----------
 
     def unify_affine_e(self, pa, ba):
-        self.equations.append(UEq.Eq( self.to_ueq(pa,in_subproc=True),
-                                      self.to_ueq(ba) ))
+        self.equations.append(UEq.Eq(self.to_ueq(pa, in_subproc=True),
+                                     self.to_ueq(ba)))
 
     def unify_bool_hole(self, pe, be):
         assert pe.type == be.type == T.bool
@@ -868,7 +890,7 @@ class Unification:
 
     def unify_stmts(self, proc_s, block_s):
         if len(proc_s) != len(block_s):
-            ploc, bloc = "",""
+            ploc, bloc = "", ""
             if len(proc_s) > 0:
                 ploc = f" (@{proc_s[0].srcinfo})"
             if len(block_s) > 0:
@@ -879,7 +901,7 @@ class Unification:
         elif len(proc_s) == 0:
             return
 
-        ps, proc_s  = proc_s[0], proc_s[1:]
+        ps, proc_s = proc_s[0], proc_s[1:]
         bs, block_s = block_s[0], block_s[1:]
 
         if type(ps) is not type(bs):
@@ -928,7 +950,7 @@ class Unification:
             pvar = BufVar(ps.lhs, ps.rhs.type.as_tensor, use_win=False)
             pvar.set_buf_solution(bs.lhs)
             self.buf_unknowns[ps.lhs] = pvar
-            self.bbuf_types[bs.lhs]   = bs.rhs.type.as_tensor
+            self.bbuf_types[bs.lhs] = bs.rhs.type.as_tensor
 
         # tail recursion
         self.unify_stmts(proc_s, block_s)
@@ -951,9 +973,9 @@ class Unification:
             pvar.set_buf_solution(bname)
 
     def unify_accesses(self, pnode, bnode):
-        pbuf, pidx  = pnode.name, pnode.idx
-        bbuf, bidx  = bnode.name, bnode.idx
-        pvar        = self.buf_unknowns[pbuf]
+        pbuf, pidx = pnode.name, pnode.idx
+        bbuf, bidx = bnode.name, bnode.idx
+        pvar = self.buf_unknowns[pbuf]
 
         idx_gap = len(bidx) - len(pidx)
         # first, reject any numbers of indices that absolutely
@@ -1031,10 +1053,10 @@ class Unification:
             # now construct the equations relating the indexing on
             # the two sides of this access in all possible cases
             def case_conj(case_idxs):
-                eqs         = []
-                tmp_pidx    = pidx.copy()
+                eqs = []
+                tmp_pidx = pidx.copy()
                 assert len(bidx) == len(case_idxs)
-                for bi, wi in zip(bidx,case_idxs):
+                for bi, wi in zip(bidx, case_idxs):
                     be = self.to_ueq(bi)
                     if isinstance(wi, Sym):  # point access from window
                         pe = UEq.Var(wi)
@@ -1047,17 +1069,16 @@ class Unification:
                 return UEq.Conj(eqs)
 
             cases = UEq.Cases(pvar.case_var,
-                              [ case_conj(cidxs) for cidxs in pvar.cases ])
+                              [case_conj(cidxs) for cidxs in pvar.cases])
             self.equations.append(cases)
-
 
     def unify_types(self, pt, bt, pnode, bnode):
         if pt.is_real_scalar() and bt.is_real_scalar():
-            return # success
+            return  # success
         elif pt.is_indexable() and bt.is_indexable():
-            return # success
+            return  # success
         elif pt == T.bool and bt == T.bool:
-            return # success
+            return  # success
         elif pt.is_tensor_or_window() and bt.is_tensor_or_window():
             if len(pt.shape()) != len(bt.shape()):
                 raise UnificationError(
@@ -1065,8 +1086,8 @@ class Unification:
                     f"{len(pt.shape())} dimensions (@{pnode.srcinfo}) with "
                     f"a tensor-type of {len(bt.shape())} dimensions "
                     f"(@{bnode.srcinfo})")
-            for psz,bsz in zip(pt.shape(),bt.shape()):
-                self.unify_affine_e(psz,bsz)
+            for psz, bsz in zip(pt.shape(), bt.shape()):
+                self.unify_affine_e(psz, bsz)
         else:
             raise UnificationError(
                 f"cannot unify type {pt} (@{pnode.srcinfo}) with "

--- a/src/exo/new_eff.py
+++ b/src/exo/new_eff.py
@@ -12,40 +12,46 @@ from .proc_eqv import get_repr_proc
 # Useful Basic Concepts and Structured Data
 
 _simple_proc_cache = dict()
+
+
 def get_simple_proc(proc):
     orig_repr = get_repr_proc(proc)
     if orig_repr not in _simple_proc_cache:
         _simple_proc_cache[orig_repr] = Alpha_Rename(orig_repr).result()
     return _simple_proc_cache[orig_repr]
 
+
 @dataclass
 class APoint:
-    name    : Sym
-    coords  : list[A.expr]
-    typ     : Any
+    name: Sym
+    coords: list[A.expr]
+    typ: Any
+
 
 @dataclass
 class AWinCoord:
-    is_pt   : bool
-    val     : A.expr
+    is_pt: bool
+    val: A.expr
+
 
 @dataclass
 class AWin:
-    name    : Sym
-    coords  : list[AWinCoord]
-    strides : list[A.expr]
+    name: Sym
+    coords: list[AWinCoord]
+    strides: list[A.expr]
 
     def __str__(win):
         def coordstr(c):
             op = '=' if c.is_pt else '+'
             return f"{op}{c.val}"
+
         coords = ''
         if len(win.coords) > 0:
-            coords = ','+(','.join([coordstr(c) for c in win.coords]))
+            coords = ',' + (','.join([coordstr(c) for c in win.coords]))
         return f"({win.name}{coords})"
 
     def nslots(self):
-        return sum([ not c.is_pt for c in self.coords ])
+        return sum([not c.is_pt for c in self.coords])
 
     # compose with another AWin
     def __add__(lhs, rhs):
@@ -53,49 +59,50 @@ class AWin:
         # ignore rhs.name
         # check that the number of coordinates is compatible
         assert lhs.nslots() == len(rhs.coords)
-        ri      = 0
-        coords  = []
+        ri = 0
+        coords = []
         for lc in lhs.coords:
             if lc.is_pt:
-                coords.append( lc )
+                coords.append(lc)
             else:
                 rc = rhs.coords[ri]
                 ri += 1
-                coords.append( AWinCoord(rc.is_pt, rc.val + lc.val) )
+                coords.append(AWinCoord(rc.is_pt, rc.val + lc.val))
         return AWin(lhs.name, coords, lhs.strides)
 
     # apply to a point
     def __call__(self, pt):
         assert isinstance(pt, APoint)
         assert self.nslots() == len(pt.coords)
-        pi      = 0
-        coords  = []
+        pi = 0
+        coords = []
         for wc in self.coords:
             if wc.is_pt:
-                coords.append( wc.val )
+                coords.append(wc.val)
             else:
-                coords.append( wc.val + pt.coords[pi] )
+                coords.append(wc.val + pt.coords[pi])
                 pi += 1
         return APoint(self.name, coords, pt.typ)
 
     # get a stride
     def get_stride(self, ndim):
-        interval_strides = [ s for c,s in zip(self.coords, self.strides)
-                               if not c.is_pt ]
+        interval_strides = [s for c, s in zip(self.coords, self.strides)
+                            if not c.is_pt]
         return interval_strides[ndim]
 
+
 def AWinAlloc(name, sizes):
-    assert all(isinstance(sz,LoopIR.expr) for sz in sizes)
-    coords  = [ AWinCoord(is_pt=False, val=AInt(0)) for _ in sizes ]
-    strides = [ A.Stride(name, i, T.stride, null_srcinfo())
-                for i in range(len(sizes)) ]
+    assert all(isinstance(sz, LoopIR.expr) for sz in sizes)
+    coords = [AWinCoord(is_pt=False, val=AInt(0)) for _ in sizes]
+    strides = [A.Stride(name, i, T.stride, null_srcinfo())
+               for i in range(len(sizes))]
 
     # fill out constant strides where possible
     if len(strides) > 0:
         strides[-1] = AInt(1)
-        sprod   = 1
-        for i in reversed(range(len(sizes)-1)):
-            sz = sizes[i+1]
+        sprod = 1
+        for i in reversed(range(len(sizes) - 1)):
+            sz = sizes[i + 1]
             if isinstance(sz, LoopIR.Const):
                 sprod *= sz.val
                 strides[i] = AInt(sprod)
@@ -104,54 +111,60 @@ def AWinAlloc(name, sizes):
 
     return AWin(name, coords, strides)
 
+
 # --------------------------------------------------------------------------- #
 # --------------------------------------------------------------------------- #
 # Analysis Environments
 
 @dataclass
 class TupleBinding:
-    names   : list[Sym]
-    rhs     : Any
+    names: list[Sym]
+    rhs: Any
+
 
 @dataclass
 class BindingList:
-    names   : list[Sym]
-    rhs     : list[Any]
+    names: list[Sym]
+    rhs: list[Any]
+
 
 @dataclass
 class WinBind:
-    name    : Sym
-    rhs     : AWin
+    name: Sym
+    rhs: AWin
+
 
 class AEnv:
     def __init__(self, name=None, expr=None, addnames=False):
         # bindings stored in order of definition
         # reverse order from application
-        self.bindings   = []
-        self.names      = set()
+        self.bindings = []
+        self.names = set()
         if name is None:
             return
         elif isinstance(name, Sym):
             if isinstance(expr, A.expr):
-                self.bindings = [BindingList([name],[expr])]
+                self.bindings = [BindingList([name], [expr])]
             else:
                 assert isinstance(expr, AWin)
-                self.bindings = [WinBind(name,expr)]
+                self.bindings = [WinBind(name, expr)]
 
             if addnames:
                 self.names.add(name)
         elif type(name) is list:
             assert isinstance(expr, A.expr)
             assert type(expr.type) is tuple and len(name) == len(expr.type)
-            self.bindings = [TupleBinding(name,expr)]
+            self.bindings = [TupleBinding(name, expr)]
 
             if addnames:
                 self.names = self.names.union(name)
-        else: assert False, "bad case"
+        else:
+            assert False, "bad case"
 
     def __str__(self):
         if len(self.bindings) == 0:
             return '[]'
+
         def bstr(bd):
             if isinstance(bd, TupleBinding):
                 nm = ','.join([str(n) for n in bd.names])
@@ -159,10 +172,12 @@ class AEnv:
             elif isinstance(bd, WinBind):
                 return f"[{bd.name} ↦ {bd.rhs}]"
             elif isinstance(bd, BindingList):
-                return ''.join([ f"[{x} ↦ {v}]"
-                                 for x,v in zip(bd.names, bd.rhs) ])
-            else: assert False, "bad case"
-        return ''.join([ bstr(bd) for bd in self.bindings ])
+                return ''.join([f"[{x} ↦ {v}]"
+                                for x, v in zip(bd.names, bd.rhs)])
+            else:
+                assert False, "bad case"
+
+        return ''.join([bstr(bd) for bd in self.bindings])
 
     def __add__(lhs, rhs):
         assert isinstance(rhs, AEnv)
@@ -170,13 +185,13 @@ class AEnv:
         # compression optimization
         if len(lhs.bindings) > 0 and len(rhs.bindings) > 0:
             lb, rb = lhs.bindings[-1], rhs.bindings[0]
-            if isinstance(lb,BindingList) and isinstance(rb, BindingList):
+            if isinstance(lb, BindingList) and isinstance(rb, BindingList):
                 mb = BindingList(lb.names + rb.names, lb.rhs + rb.rhs)
                 result.bindings = lhs.bindings[:-1] + [mb] + rhs.bindings[1:]
                 return result
         # otherwise
         result.bindings = lhs.bindings + rhs.bindings
-        result.names    = lhs.names.union(rhs.names)
+        result.names = lhs.names.union(rhs.names)
         return result
 
     def __call__(self, arg):
@@ -191,23 +206,25 @@ class AEnv:
                     # TODO: Probably need to introduce let bindings
                     # for coordinates in a way to get the values of globals
                     # at the site of windowing correct
-                    #raise NotImplementedError("TODO: how to handle?")
+                    # raise NotImplementedError("TODO: how to handle?")
                 elif isinstance(bd, BindingList):
                     res = ALet(bd.names, bd.rhs, res)
-                else: assert False, "bad case"
+                else:
+                    assert False, "bad case"
             return res
         elif isinstance(arg, list) and len(arg) == 0:
             return []
         elif isinstance(arg, list) and isinstance(arg[0], E.eff):
             return [E.BindEnv(self)] + arg
-        else: assert False, f"Cannot apply AEnv to {type(arg)}"
+        else:
+            assert False, f"Cannot apply AEnv to {type(arg)}"
 
     def translate_win(self, winmap):
         winmap = winmap.copy()
         for bd in self.bindings:
             if isinstance(bd, WinBind):
-                win     = bd.rhs
-                prewin  = winmap.get(win.name, None)
+                win = bd.rhs
+                prewin = winmap.get(win.name, None)
                 if prewin is not None:
                     win = prewin + win
                 winmap[bd.name] = win
@@ -219,14 +236,14 @@ class AEnv:
         nmtyp = OrderedDict()
         for bd in self.bindings:
             if isinstance(bd, TupleBinding):
-                for n,rt in zip(bd.names, bd.rhs.type):
+                for n, rt in zip(bd.names, bd.rhs.type):
                     if n in self.names:
                         assert n not in nmtyp or nmtyp[n] == rt
                         nmtyp[n] = rt
             elif isinstance(bd, WinBind):
-                pass # ignore windows for this
+                pass  # ignore windows for this
             elif isinstance(bd, BindingList):
-                for n,r in zip(bd.names, bd.rhs):
+                for n, r in zip(bd.names, bd.rhs):
                     if n in self.names:
                         nmtyp[n] = r.type
         return nmtyp
@@ -234,22 +251,22 @@ class AEnv:
     # we assume this packs up a scoping level
     # and therefore drop any WinBinds in the process
     def bind_to_copies(self):
-        nmtyps      = self.names_types()
-        orig_vars   = [ A.Var(nm, typ, null_srcinfo())
-                        for nm,typ in nmtyps.items() ]
-        copy_vars   = [ A.Var(nm.copy(), typ, null_srcinfo())
-                        for nm,typ in nmtyps.items() ]
-        varmap      = OrderedDict({ nm : copyv
-                            for (nm,_),copyv in zip(nmtyps.items(),
-                                                    copy_vars)})
+        nmtyps = self.names_types()
+        orig_vars = [A.Var(nm, typ, null_srcinfo())
+                     for nm, typ in nmtyps.items()]
+        copy_vars = [A.Var(nm.copy(), typ, null_srcinfo())
+                     for nm, typ in nmtyps.items()]
+        varmap = OrderedDict({nm: copyv
+                              for (nm, _), copyv in zip(nmtyps.items(),
+                                                        copy_vars)})
 
-        body        = A.Tuple(orig_vars, tuple(e.type for e in orig_vars),
-                                         null_srcinfo())
+        body = A.Tuple(orig_vars, tuple(e.type for e in orig_vars),
+                       null_srcinfo())
         # wrap the tuple in let-bindings representing this entire AEnv
-        body        = self(body)
+        body = self(body)
         # then construct an AEnv that maps the new variable symbols
         # to these values
-        new_env     = AEnv([ v.name for v in copy_vars ], body, addnames=True)
+        new_env = AEnv([v.name for v in copy_vars], body, addnames=True)
         return varmap, new_env
 
 
@@ -259,16 +276,18 @@ def aenv_join(aenvs):
         aenv = aenv + a
     return aenv
 
+
 def AEnvPar(bind_dict, addnames=False):
     if len(bind_dict) == 0:
         return AEnv()
     names, rhs, types = [], [], []
-    for nm,e in bind_dict.items():
+    for nm, e in bind_dict.items():
         names.append(nm)
         rhs.append(e)
         types.append(e.type)
     rhs_tuple = A.Tuple(rhs, tuple(types), rhs[0].srcinfo)
     return AEnv(names, rhs_tuple, addnames=addnames)
+
 
 # --------------------------------------------------------------------------- #
 # --------------------------------------------------------------------------- #
@@ -279,17 +298,19 @@ def lift_e(e):
     if isinstance(e, LoopIR.WindowExpr):
         def lift_w(w):
             if isinstance(w, LoopIR.Interval):
-                return AWinCoord(is_pt=False,val=lift_e(w.lo))
+                return AWinCoord(is_pt=False, val=lift_e(w.lo))
             elif isinstance(w, LoopIR.Point):
-                return AWinCoord(is_pt=True,val=lift_e(w.pt))
-            else: assert False, f"bad w_access case"
+                return AWinCoord(is_pt=True, val=lift_e(w.pt))
+            else:
+                assert False, f"bad w_access case"
+
         # default strides
-        strides = [ A.Stride(e.name, i, T.stride, e.srcinfo)
-                    for i in range(len(e.idx)) ]
-        return AWin(e.name,[ lift_w(w) for w in e.idx ], strides)
+        strides = [A.Stride(e.name, i, T.stride, e.srcinfo)
+                   for i in range(len(e.idx))]
+        return AWin(e.name, [lift_w(w) for w in e.idx], strides)
     else:
         if (e.type.is_indexable() or e.type.is_stridable() or
-            e.type == T.bool):
+                e.type == T.bool):
             if isinstance(e, LoopIR.Read):
                 assert len(e.idx) == 0
                 return A.Var(e.name, e.type, e.srcinfo)
@@ -301,16 +322,19 @@ def lift_e(e):
             elif isinstance(e, LoopIR.USub):
                 return A.USub(lift_e(e.arg), e.type, e.srcinfo)
             elif isinstance(e, LoopIR.StrideExpr):
-                return A.Stride( e.name, e.dim, e.type, e.srcinfo )
+                return A.Stride(e.name, e.dim, e.type, e.srcinfo)
             elif isinstance(e, LoopIR.ReadConfig):
                 globname = e.config._INTERNAL_sym(e.field)
-                return A.Var( globname, e.type, e.srcinfo )
-            else: f"bad case: {type(e)}"
+                return A.Var(globname, e.type, e.srcinfo)
+            else:
+                f"bad case: {type(e)}"
         else:
             return A.Unk(T.err, e.srcinfo)
 
+
 def lift_es(es):
-    return [ lift_e(e) for e in es ]
+    return [lift_e(e) for e in es]
+
 
 def globenv(stmts):
     aenvs = []
@@ -318,77 +342,78 @@ def globenv(stmts):
         if isinstance(s, LoopIR.WriteConfig):
             # don't bother tracking 
             if not s.rhs.type.is_numeric():
-                globname    = s.config._INTERNAL_sym(s.field)
-                rhs         = lift_e(s.rhs)
+                globname = s.config._INTERNAL_sym(s.field)
+                rhs = lift_e(s.rhs)
                 aenvs.append(AEnv(globname, rhs, addnames=True))
         elif isinstance(s, LoopIR.WindowStmt):
-            win         = lift_e(s.rhs)
+            win = lift_e(s.rhs)
             aenvs.append(AEnv(s.lhs, win))
         elif isinstance(s, LoopIR.Alloc):
-            win         = AWinAlloc(s.name, s.type.shape())
-            aenvs.append(AEnv(s.name,win))
+            win = AWinAlloc(s.name, s.type.shape())
+            aenvs.append(AEnv(s.name, win))
         elif isinstance(s, LoopIR.If):
             # extract environments for each side of the branch
-            body_env    = globenv(s.body)
-            else_env    = globenv(s.orelse)
+            body_env = globenv(s.body)
+            else_env = globenv(s.orelse)
             # get the map from old to new names, and binding env
-            bvarmap, benv   = body_env.bind_to_copies()
-            evarmap, eenv   = else_env.bind_to_copies()
-            aenvs      += [benv, eenv]
-            oldvars     = { nm : A.Var(nm, newv.type, s.srcinfo)
-                            for nm, newv in chain(bvarmap.items(),
-                                                  evarmap.items()) }
+            bvarmap, benv = body_env.bind_to_copies()
+            evarmap, eenv = else_env.bind_to_copies()
+            aenvs += [benv, eenv]
+            oldvars = {nm: A.Var(nm, newv.type, s.srcinfo)
+                       for nm, newv in chain(bvarmap.items(),
+                                             evarmap.items())}
 
             # bind the condition so it isn't duplicated
-            condsym     = Sym('if_cond')
-            condvar     = A.Var(condsym, T.bool, s.cond.srcinfo)
-            cond        = lift_e(s.cond)
+            condsym = Sym('if_cond')
+            condvar = A.Var(condsym, T.bool, s.cond.srcinfo)
+            cond = lift_e(s.cond)
             aenvs.append(AEnv(condsym, cond))
 
             # We must now construct an environment that defines the
             # new value for variables `x` among the possibilities
-            newbinds    = dict()
-            for nm,oldv in oldvars.items():
+            newbinds = dict()
+            for nm, oldv in oldvars.items():
                 # default to old-value
-                tcase   = bvarmap.get(nm,oldv)
-                fcase   = evarmap.get(nm,oldv)
-                val     = A.Select(condvar, tcase, fcase, oldv.type, s.srcinfo)
+                tcase = bvarmap.get(nm, oldv)
+                fcase = evarmap.get(nm, oldv)
+                val = A.Select(condvar, tcase, fcase, oldv.type, s.srcinfo)
                 newbinds[nm] = val
-            aenvs.append(AEnvPar(newbinds,addnames=True))
+            aenvs.append(AEnvPar(newbinds, addnames=True))
 
         elif isinstance(s, LoopIR.Seq):
             # extract environment for the body and bind its
             # results via copies of the variables
-            body_env    = globenv(s.body)
-            bvarmap, benv   = body_env.bind_to_copies()
+            body_env = globenv(s.body)
+            bvarmap, benv = body_env.bind_to_copies()
             aenvs.append(benv)
 
             # bind the bounds condition so it isn't duplicated
-            #bdssym      = Sym('for_bounds')
-            #bdsvar      = ABool(bdssym)
-            bds         = AAnd(AInt(0) <= AInt(s.iter),
-                               AInt(s.iter) < lift_e(s.hi))
-            def fix(x,body_x):
-                arg     = AImplies(bds, AEq(body_x,x))
+            # bdssym      = Sym('for_bounds')
+            # bdsvar      = ABool(bdssym)
+            bds = AAnd(AInt(0) <= AInt(s.iter),
+                       AInt(s.iter) < lift_e(s.hi))
+
+            def fix(x, body_x):
+                arg = AImplies(bds, AEq(body_x, x))
                 return A.ForAll(s.iter, arg, T.bool, s.srcinfo)
 
             # Now construct an environment that defines the new
             # value for variables `x` based on fixed-point conditions
-            newbinds    = dict()
-            for nm,bvar in bvarmap.items():
-                oldvar  = A.Var(nm, bvar.type, s.srcinfo)
-                val     = A.Select(fix(oldvar, bvar),
-                                   oldvar,
-                                   A.Unk(oldvar.type, s.srcinfo),
-                                   oldvar.type, s.srcinfo)
+            newbinds = dict()
+            for nm, bvar in bvarmap.items():
+                oldvar = A.Var(nm, bvar.type, s.srcinfo)
+                val = A.Select(fix(oldvar, bvar),
+                               oldvar,
+                               A.Unk(oldvar.type, s.srcinfo),
+                               oldvar.type, s.srcinfo)
                 newbinds[nm] = val
-            aenvs.append(AEnvPar(newbinds,addnames=True))
+            aenvs.append(AEnvPar(newbinds, addnames=True))
 
         elif isinstance(s, LoopIR.Call):
-            sub_proc    = get_simple_proc(s.f)
-            sub_env     = globenv_proc(sub_proc)
-            call_env    = call_bindings(s.args, sub_proc.args)
-            aenvs      += [call_env, sub_env]
+            sub_proc = get_simple_proc(s.f)
+            sub_env = globenv_proc(sub_proc)
+            call_env = call_bindings(s.args, sub_proc.args)
+            aenvs += [call_env, sub_env]
 
         else:
             pass
@@ -398,13 +423,13 @@ def globenv(stmts):
 
 def call_bindings(call_args, sig_args):
     assert len(call_args) == len(sig_args)
-    aenvs   = []
-    for a,fa in zip(call_args, sig_args):
+    aenvs = []
+    for a, fa in zip(call_args, sig_args):
         if fa.type.is_numeric():
             if isinstance(a, LoopIR.WindowExpr):
-                aenvs.append( AEnv(fa.name, lift_e(a)) )
+                aenvs.append(AEnv(fa.name, lift_e(a)))
             elif isinstance(a, LoopIR.ReadConfig):
-                aenvs.append( AEnv(fa.name, lift_e(a)) )
+                aenvs.append(AEnv(fa.name, lift_e(a)))
             else:
                 assert isinstance(a, LoopIR.Read)
                 # determine whether or not this is a scalar or tensor
@@ -412,22 +437,21 @@ def call_bindings(call_args, sig_args):
                 # in order to avoid stupid errors in the lowering
                 shape = fa.type.shape()
                 if len(shape) > 0:
-                    aenvs.append( AEnv(fa.name, AWinAlloc(a.name, shape)) )
+                    aenvs.append(AEnv(fa.name, AWinAlloc(a.name, shape)))
                 else:
-                    aenvs.append( AEnv(fa.name, AWin(a.name,[],[])) )
+                    aenvs.append(AEnv(fa.name, AWin(a.name, [], [])))
         else:
-            aenvs.append( AEnv(fa.name, lift_e(a)) )
+            aenvs.append(AEnv(fa.name, lift_e(a)))
     return aenv_join(aenvs)
 
 
 _globenv_proc_cache = dict()
+
+
 def globenv_proc(proc):
     if proc not in _globenv_proc_cache:
         _globenv_proc_cache[proc] = globenv(proc.body)
     return _globenv_proc_cache[proc]
-
-
-
 
 
 # --------------------------------------------------------------------------- #
@@ -453,61 +477,67 @@ module LocSet {
             | LetEnv    ( aenv   env, locset arg )
             | HideAlloc ( sym   name, locset arg )
 } """, {
-    'sym':   Sym,
+    'sym': Sym,
     'aexpr': A.expr,
-    'aenv':  AEnv,
-    'type':  is_type_bound,
+    'aenv': AEnv,
+    'type': is_type_bound,
 })
-
 
 ls_prec = {
     #
     "bigunion": 10,
     #
-    "union":    20,
-    "isct":     20,
-    "diff":     20,
+    "union": 20,
+    "isct": 20,
+    "diff": 20,
 }
 
-def LUnion(lhs,rhs):
+
+def LUnion(lhs, rhs):
     if isinstance(lhs, LS.Empty):
         return rhs
     elif isinstance(rhs, LS.Empty):
         return lhs
     else:
-        return LS.Union(lhs,rhs)
+        return LS.Union(lhs, rhs)
 
-def LIsct(lhs,rhs):
+
+def LIsct(lhs, rhs):
     if isinstance(lhs, LS.Empty) or isinstance(rhs, LS.Empty):
         return LS.Empty()
     else:
-        return LS.Isct(lhs,rhs)
+        return LS.Isct(lhs, rhs)
 
-def LDiff(lhs,rhs):
+
+def LDiff(lhs, rhs):
     if isinstance(lhs, LS.Empty):
         return LS.Empty()
     elif isinstance(rhs, LS.Empty):
         return lhs
     else:
-        return LS.Diff(lhs,rhs)
+        return LS.Diff(lhs, rhs)
+
 
 def LBigUnion(name, arg):
     if isinstance(arg, LS.Empty):
         return LS.Empty()
     else:
-        return LS.BigUnion(name,arg)
+        return LS.BigUnion(name, arg)
+
 
 def LFilter(cond, arg):
     if isinstance(arg, LS.Empty):
         return LS.Empty()
     else:
-        return LS.Filter(cond,arg)
+        return LS.Filter(cond, arg)
+
 
 def LLetEnv(env, arg):
     if isinstance(arg, LS.Empty):
         return LS.Empty()
     else:
-        return LS.LetEnv(env,arg)
+        return LS.LetEnv(env, arg)
+
 
 def LHideAlloc(name, arg):
     if isinstance(arg, LS.Empty):
@@ -515,18 +545,19 @@ def LHideAlloc(name, arg):
     else:
         return LS.HideAlloc(name, arg)
 
+
 # pretty printing
 def _lsstr(ls, prec=0):
     if isinstance(ls, LS.Empty):
         return "∅"
     elif isinstance(ls, LS.Point):
         coords = ','.join([str(a) for a in ls.coords])
-        typ    = f":{ls.type}" if ls.type else ""
+        typ = f":{ls.type}" if ls.type else ""
         return f"{{({ls.name},{coords}{typ})}}"
     elif isinstance(ls, LS.WholeBuf):
         coords = ','.join([str(a) for a in ls.coords])
         return f"{{{ls.name}|{ls.ndim}}}"
-    elif isinstance(ls, (LS.Union,LS.Isct,LS.Diff)):
+    elif isinstance(ls, (LS.Union, LS.Isct, LS.Diff)):
         if isinstance(ls, LS.Union):
             op, local_prec = '∪', ls_prec['union']
         elif isinstance(ls, LS.Isct):
@@ -551,7 +582,9 @@ def _lsstr(ls, prec=0):
     elif isinstance(ls, LS.HideAlloc):
         arg = _lsstr(ls.arg)
         return f"alloc({ls.name},{arg})"
-    else: assert False, f"bad case: {type(ls)}"
+    else:
+        assert False, f"bad case: {type(ls)}"
+
 
 @extclass(LS.locset)
 def __str__(ls):
@@ -566,21 +599,21 @@ def is_elem(pt, ls, win_map=None, alloc_masks=None):
     if isinstance(ls, LS.Empty):
         return ABool(False)
     elif isinstance(ls, LS.Point):
-        lspt        = APoint(ls.name, ls.coords, ls.type)
+        lspt = APoint(ls.name, ls.coords, ls.type)
         if ls.name in win_map:
-            lspt    = win_map[ls.name](lspt)
+            lspt = win_map[ls.name](lspt)
 
         if pt.name != lspt.name or lspt.name in alloc_masks:
             return ABool(False)
         assert len(pt.coords) == len(lspt.coords)
-        eqs = [ AEq(q,p) for q,p in zip(pt.coords,lspt.coords) ]
+        eqs = [AEq(q, p) for q, p in zip(pt.coords, lspt.coords)]
         return AAnd(*eqs)
     elif isinstance(ls, LS.WholeBuf):
-        bufname     = ls.name
+        bufname = ls.name
         if bufname in win_map:
             bufname = win_map[bufname].name
         return ABool(pt.name == bufname)
-    elif isinstance(ls, (LS.Union,LS.Isct,LS.Diff)):
+    elif isinstance(ls, (LS.Union, LS.Isct, LS.Diff)):
         lhs = is_elem(pt, ls.lhs, win_map=win_map, alloc_masks=alloc_masks)
         rhs = is_elem(pt, ls.rhs, win_map=win_map, alloc_masks=alloc_masks)
         if isinstance(ls, LS.Union):
@@ -589,7 +622,8 @@ def is_elem(pt, ls, win_map=None, alloc_masks=None):
             return AAnd(lhs, rhs)
         elif isinstance(ls, LS.Diff):
             return AAnd(lhs, ANot(rhs))
-        else: assert False
+        else:
+            assert False
     elif isinstance(ls, LS.BigUnion):
         arg = is_elem(pt, ls.arg, win_map=win_map, alloc_masks=alloc_masks)
         return A.Exists(ls.name, arg, T.bool, null_srcinfo())
@@ -606,10 +640,13 @@ def is_elem(pt, ls, win_map=None, alloc_masks=None):
         res = is_elem(pt, ls.arg, win_map=win_map, alloc_masks=alloc_masks)
         alloc_masks.pop()
         return res
-    else: assert False, f"bad case: {type(ls)}"
+    else:
+        assert False, f"bad case: {type(ls)}"
+
 
 def get_point_exprs(ls):
     all_bufs = dict()
+
     def _collect_buf(ls, win_map, alloc_masks):
         # default arg
         win_map = win_map or dict()
@@ -618,19 +655,19 @@ def get_point_exprs(ls):
         if isinstance(ls, LS.Empty):
             pass
         elif isinstance(ls, LS.Point):
-            lspt        = APoint(ls.name, ls.coords, ls.type)
+            lspt = APoint(ls.name, ls.coords, ls.type)
             if ls.name in win_map:
-                lspt    = win_map[ls.name](lspt)
+                lspt = win_map[ls.name](lspt)
 
             if lspt.name not in alloc_masks:
-                all_bufs[lspt.name] = (len(lspt.coords),ls.type)
+                all_bufs[lspt.name] = (len(lspt.coords), ls.type)
         elif isinstance(ls, LS.WholeBuf):
-            bufname     = ls.name
+            bufname = ls.name
             if bufname in win_map:
                 bufname = win_map[bufname].name
             if bufname not in alloc_masks:
-                all_bufs[bufname] = (ls.ndim,T.R)
-        elif isinstance(ls, (LS.Union,LS.Isct,LS.Diff)):
+                all_bufs[bufname] = (ls.ndim, T.R)
+        elif isinstance(ls, (LS.Union, LS.Isct, LS.Diff)):
             _collect_buf(ls.lhs, win_map, alloc_masks)
             _collect_buf(ls.rhs, win_map, alloc_masks)
         elif isinstance(ls, (LS.BigUnion, LS.Filter, LS.LetEnv)):
@@ -639,19 +676,21 @@ def get_point_exprs(ls):
             alloc_masks.append(ls.name)
             _collect_buf(ls.arg, win_map, alloc_masks)
             alloc_masks.pop()
+
     _collect_buf(ls, dict(), [])
 
-    points = [ APoint(nm, [ AInt(Sym(f"i{i}")) for i in range(ndim) ],
-                      typ)
-               for nm,(ndim,typ) in all_bufs.items() ]
+    points = [APoint(nm, [AInt(Sym(f"i{i}")) for i in range(ndim)],
+                     typ)
+              for nm, (ndim, typ) in all_bufs.items()]
     return points
 
+
 def is_empty(ls):
-    points  = get_point_exprs(ls)
+    points = get_point_exprs(ls)
 
     terms = []
     for pt in points:
-        term    = A.Not(is_elem(pt,ls), T.bool, null_srcinfo())
+        term = A.Not(is_elem(pt, ls), T.bool, null_srcinfo())
         for iv in reversed(pt.coords):
             term = A.ForAll(iv.name, term, T.bool, null_srcinfo())
         terms.append(term)
@@ -680,23 +719,24 @@ module EffectsNew {
          --
          | Alloc        ( sym name, int ndim )
 } """, {
-    'sym':   Sym,
+    'sym': Sym,
     'aexpr': A.expr,
-    'aenv':  AEnv,
-    'type':  is_type_bound,
+    'aenv': AEnv,
+    'type': is_type_bound,
     # 'srcinfo': lambda x: isinstance(x, SrcInfo),
 })
 
+
 # pretty printing
-def _effstr(eff,tab=""):
+def _effstr(eff, tab=""):
     if isinstance(eff, E.Empty):
         return f"{tab}∅"
-    elif isinstance(eff, (E.Guard,E.Loop)):
-        lines   = [ _effstr(e,tab+'  ') for e in eff.body ]
+    elif isinstance(eff, (E.Guard, E.Loop)):
+        lines = [_effstr(e, tab + '  ') for e in eff.body]
         if isinstance(eff, E.Guard):
-            lines = [ f"{tab}Guard({eff.cond})" ] + lines
+            lines = [f"{tab}Guard({eff.cond})"] + lines
         else:
-            lines = [ f"{tab}Loop({eff.name})" ] + lines
+            lines = [f"{tab}Loop({eff.name})"] + lines
         return '\n'.join(lines)
     elif isinstance(eff, E.BindEnv):
         return f"{tab}{eff.env}"
@@ -704,14 +744,16 @@ def _effstr(eff,tab=""):
         nm = 'GlobalRead' if isinstance(eff, E.GlobalRead) else 'GlobalWrite'
         return f"{tab}{nm}({eff.name},{eff.type})"
     elif isinstance(eff, (E.Read, E.Write, E.Reduce)):
-        nm = ('Read'    if isinstance(eff, E.Read) else
-              'Write'   if isinstance(eff, E.Write) else
+        nm = ('Read' if isinstance(eff, E.Read) else
+              'Write' if isinstance(eff, E.Write) else
               'Reduce')
-        coords = ','.join([ str(a) for a in eff.coords ])
+        coords = ','.join([str(a) for a in eff.coords])
         return f"{tab}{nm}({eff.name},{coords})"
     elif isinstance(eff, E.Alloc):
         return f"{tab}Alloc({eff.name}|{eff.ndim})"
-    else: assert False, f"bad case: {type(eff)}"
+    else:
+        assert False, f"bad case: {type(eff)}"
+
 
 @extclass(E.eff)
 def __str__(eff):
@@ -720,22 +762,23 @@ def __str__(eff):
 
 # Here are codes for different location sets...
 class ES(Enum):
-    READ_G      = 1
-    WRITE_G     = 2
-    READ_H      = 3
-    WRITE_H     = 4
-    PRE_REDUCE  = 5
+    READ_G = 1
+    WRITE_G = 2
+    READ_H = 3
+    WRITE_H = 4
+    PRE_REDUCE = 5
 
-    _DERIVED    = 6
+    _DERIVED = 6
 
-    READ_ALL    = 7
-    WRITE_ALL   = 8
-    REDUCE      = 9
-    ALL         = 10
-    MODIFY      = 11
-    READ_WRITE  = 12
+    READ_ALL = 7
+    WRITE_ALL = 8
+    REDUCE = 9
+    ALL = 10
+    MODIFY = 11
+    READ_WRITE = 12
 
-    ALLOC       = 13
+    ALLOC = 13
+
 
 def get_basic_locsets(effs):
     RG = LS.Empty()
@@ -750,65 +793,67 @@ def get_basic_locsets(effs):
 
         elif isinstance(eff, E.GlobalRead):
             ls1 = LS.Point(eff.name, [], eff.type)
-            RG  = LUnion(ls1, RG)
+            RG = LUnion(ls1, RG)
         elif isinstance(eff, E.GlobalWrite):
             ls1 = LS.Point(eff.name, [], eff.type)
-            RG  = LDiff(RG, ls1)
-            WG  = LUnion(ls1, WG)
+            RG = LDiff(RG, ls1)
+            WG = LUnion(ls1, WG)
         elif isinstance(eff, E.Read):
             ls1 = LS.Point(eff.name, eff.coords, None)
-            RH  = LUnion(ls1, RH)
+            RH = LUnion(ls1, RH)
         elif isinstance(eff, E.Write):
             ls1 = LS.Point(eff.name, eff.coords, None)
-            RH  = LDiff(RH, ls1)
-            WH  = LUnion(ls1, WH)
+            RH = LDiff(RH, ls1)
+            WH = LUnion(ls1, WH)
         elif isinstance(eff, E.Reduce):
             ls1 = LS.Point(eff.name, eff.coords, None)
             Red = LUnion(ls1, Red)
 
         elif isinstance(eff, E.Alloc):
-            RG  = LHideAlloc(eff.name, RG)
-            WG  = LHideAlloc(eff.name, WG)
-            RH  = LHideAlloc(eff.name, RH)
-            WH  = LHideAlloc(eff.name, WH)
+            RG = LHideAlloc(eff.name, RG)
+            WG = LHideAlloc(eff.name, WG)
+            RH = LHideAlloc(eff.name, RH)
+            WH = LHideAlloc(eff.name, WH)
             Red = LHideAlloc(eff.name, Red)
             Alc = LUnion(Alc, LS.WholeBuf(eff.name, eff.ndim))
 
         elif isinstance(eff, E.BindEnv):
-            RG  = LLetEnv(eff.env, RG)
-            WG  = LLetEnv(eff.env, WG)
-            RH  = LLetEnv(eff.env, RH)
-            WH  = LLetEnv(eff.env, WH)
+            RG = LLetEnv(eff.env, RG)
+            WG = LLetEnv(eff.env, WG)
+            RH = LLetEnv(eff.env, RH)
+            WH = LLetEnv(eff.env, WH)
             Red = LLetEnv(eff.env, Red)
 
-        elif isinstance(eff, (E.Guard,E.Loop)):
+        elif isinstance(eff, (E.Guard, E.Loop)):
             bodyLs = get_basic_locsets(eff.body)
             if isinstance(eff, E.Guard):
-                bodyLs = tuple( LFilter(eff.cond, Ls) for Ls in bodyLs )
+                bodyLs = tuple(LFilter(eff.cond, Ls) for Ls in bodyLs)
             else:
-                bodyLs = tuple( LBigUnion(eff.name, Ls) for Ls in bodyLs )
-            bRG, bWG, bRH, bWH, bRed, bAlc= bodyLs
+                bodyLs = tuple(LBigUnion(eff.name, Ls) for Ls in bodyLs)
+            bRG, bWG, bRH, bWH, bRed, bAlc = bodyLs
 
             # now do the full interaction updates...
-            RG  = LUnion(bRG, LDiff(RG, bWG))
-            WG  = LUnion(bWG, WG)
-            RH  = LUnion(bRH, LDiff(RH, bWH))
-            WH  = LUnion(bWH, WH)
+            RG = LUnion(bRG, LDiff(RG, bWG))
+            WG = LUnion(bWG, WG)
+            RH = LUnion(bRH, LDiff(RH, bWH))
+            WH = LUnion(bWH, WH)
             Red = LUnion(bRed, Red)
 
-        else: assert False, f"bad case: {type(eff)}"
+        else:
+            assert False, f"bad case: {type(eff)}"
 
-    return (RG,WG,RH,WH,Red,Alc)
+    return (RG, WG, RH, WH, Red, Alc)
 
 
 def getsets(codes, effs):
     RG, WG, RH, WH, preRed, Alc = get_basic_locsets(effs)
-    RAll    = LUnion(RG, RH)
-    WAll    = LUnion(WG, WH)
-    Red     = LDiff(preRed, WH)
-    Mod     = LUnion(WAll, preRed)
-    RW      = LUnion(RAll, WAll)
-    All     = LUnion(RW, preRed)
+    RAll = LUnion(RG, RH)
+    WAll = LUnion(WG, WH)
+    Red = LDiff(preRed, WH)
+    Mod = LUnion(WAll, preRed)
+    RW = LUnion(RAll, WAll)
+    All = LUnion(RW, preRed)
+
     def get_code(code):
         if code == ES.READ_G:
             return RG
@@ -834,10 +879,10 @@ def getsets(codes, effs):
             return RW
         elif code == ES.ALLOC:
             return Alc
-        else: assert False, f"bad case: {code}"
+        else:
+            assert False, f"bad case: {code}"
 
     return [get_code(c) for c in codes]
-
 
 
 # --------------------------------------------------------------------------- #
@@ -847,7 +892,7 @@ def getsets(codes, effs):
 def expr_effs(e):
     if isinstance(e, LoopIR.Read):
         if e.type.is_numeric():
-            return [ E.Read(e.name, lift_es(e.idx)) ]
+            return [E.Read(e.name, lift_es(e.idx))]
         else:
             return []
     elif isinstance(e, LoopIR.Const):
@@ -864,16 +909,20 @@ def expr_effs(e):
                 return expr_effs(w.lo) + expr_effs(w.hi)
             else:
                 return expr_effs(w.pt)
-        return [ eff for w in e.idx for eff in w_effs(w) ]
+
+        return [eff for w in e.idx for eff in w_effs(w)]
     elif isinstance(e, LoopIR.StrideExpr):
         return []
     elif isinstance(e, LoopIR.ReadConfig):
         globname = e.config._INTERNAL_sym(e.field)
-        return [ E.GlobalRead(globname, e.config.lookup(e.field)[1]) ]
-    else: assert False, f"bad case: {type(e)}"
+        return [E.GlobalRead(globname, e.config.lookup(e.field)[1])]
+    else:
+        assert False, f"bad case: {type(e)}"
+
 
 def list_expr_effs(es):
-    return [ eff for e in es for eff in expr_effs(e) ]
+    return [eff for e in es for eff in expr_effs(e)]
+
 
 def stmts_effs(stmts):
     effs = []
@@ -882,54 +931,58 @@ def stmts_effs(stmts):
             EConstruct = E.Write if isinstance(s, LoopIR.Assign) else E.Reduce
             effs += list_expr_effs(s.idx)
             effs += expr_effs(s.rhs)
-            effs.append( EConstruct(s.name, lift_es(s.idx)) )
+            effs.append(EConstruct(s.name, lift_es(s.idx)))
         elif isinstance(s, LoopIR.WriteConfig):
             effs += expr_effs(s.rhs)
             globname = s.config._INTERNAL_sym(s.field)
-            effs.append( E.GlobalWrite(globname, s.config.lookup(s.field)[1]) )
+            effs.append(E.GlobalWrite(globname, s.config.lookup(s.field)[1]))
         elif isinstance(s, LoopIR.If):
             effs += expr_effs(s.cond)
-            effs += [ E.Guard( lift_e(s.cond), stmts_effs(s.body) ),
-                      E.Guard( ANot(lift_e(s.cond)), stmts_effs(s.orelse) ) ]
+            effs += [E.Guard(lift_e(s.cond), stmts_effs(s.body)),
+                     E.Guard(ANot(lift_e(s.cond)), stmts_effs(s.orelse))]
         elif isinstance(s, LoopIR.Seq):
             effs += expr_effs(s.hi)
-            bds   = AAnd( AInt(0) <= AInt(s.iter),
-                          AInt(s.iter) < lift_e(s.hi) )
+            bds = AAnd(AInt(0) <= AInt(s.iter),
+                       AInt(s.iter) < lift_e(s.hi))
             # we must prefix the body with the loop-invariant dataflow
             # analysis of the loop, since that is the only precondition
             # we are sound in assuming for global values in the loop body
-            body  = ([ E.BindEnv(globenv([s])) ] + stmts_effs(s.body))
-            effs += [ E.Loop(s.iter, [E.Guard(bds, body)]) ]
+            body = ([E.BindEnv(globenv([s]))] + stmts_effs(s.body))
+            effs += [E.Loop(s.iter, [E.Guard(bds, body)])]
         elif isinstance(s, LoopIR.Call):
             # must filter out arguments that are simply
             # Read of a numeric buffer, since those arguments are
             # passed by reference, not by reading and passing a value
-            for fa,a in zip(s.f.args, s.args):
+            for fa, a in zip(s.f.args, s.args):
                 if fa.type.is_numeric() and isinstance(a, LoopIR.Read):
-                    pass # this is the case we want to skip
+                    pass  # this is the case we want to skip
                 else:
                     effs += expr_effs(a)
-            sub_proc    = get_simple_proc(s.f)
-            call_env    = call_bindings(s.args, sub_proc.args)
-            effs       += [ E.BindEnv(call_env) ]
-            effs       += proc_effs(sub_proc)
+            sub_proc = get_simple_proc(s.f)
+            call_env = call_bindings(s.args, sub_proc.args)
+            effs += [E.BindEnv(call_env)]
+            effs += proc_effs(sub_proc)
         elif isinstance(s, LoopIR.Alloc):
             if isinstance(s.type, T.Tensor):
                 effs += list_expr_effs(s.type.hi)
-            effs       += [E.Alloc(s.name, len(s.type.shape()))]
+            effs += [E.Alloc(s.name, len(s.type.shape()))]
         elif isinstance(s, LoopIR.WindowStmt):
             effs += expr_effs(s.rhs)
-        elif isinstance(s, (LoopIR.Free,LoopIR.Pass)):
+        elif isinstance(s, (LoopIR.Free, LoopIR.Pass)):
             pass
-        else: assert False, f"bad case: {type(s)}"
+        else:
+            assert False, f"bad case: {type(s)}"
 
         # secondly, insert global value modifications into
         # the sequence of effects
-        effs.append( E.BindEnv(globenv([s])) )
+        effs.append(E.BindEnv(globenv([s])))
 
     return effs
 
+
 _proc_effs_cache = dict()
+
+
 def proc_effs(proc):
     if proc not in _proc_effs_cache:
         _proc_effs_cache[proc] = stmts_effs(proc.body)
@@ -943,32 +996,32 @@ def proc_effs(proc):
 
 class ContextExtraction:
     def __init__(self, proc, stmts):
-        self.proc   = proc
-        self.stmts  = stmts
+        self.proc = proc
+        self.stmts = stmts
 
     def get_control_predicate(self):
-        assumed     = AAnd(*[ lift_e(p) for p in self.proc.preds ])
-        ctrlp       = self.ctrlp_stmts(self.proc.body)
+        assumed = AAnd(*[lift_e(p) for p in self.proc.preds])
+        ctrlp = self.ctrlp_stmts(self.proc.body)
         return AAnd(assumed, ctrlp)
 
     def get_pre_globenv(self):
         return self.preenv_stmts(self.proc.body)
 
     def get_posteffs(self):
-        a       = self.posteff_stmts(self.proc.body)
+        a = self.posteff_stmts(self.proc.body)
         if len(self.proc.preds) > 0:
-            assumed = AAnd(*[ lift_e(p) for p in self.proc.preds ])
-            a       = [E.Guard(assumed, a)]
+            assumed = AAnd(*[lift_e(p) for p in self.proc.preds])
+            a = [E.Guard(assumed, a)]
         return a
 
     def ctrlp_stmts(self, stmts):
-        for i,s in enumerate(stmts):
+        for i, s in enumerate(stmts):
             if s is self.stmts[0]:
                 return ABool(True)
             else:
                 p = self.ctrlp_s(s)
-                if p is not None: # found the focused sub-tree
-                    G   = globenv(stmts[0:i])
+                if p is not None:  # found the focused sub-tree
+                    G = globenv(stmts[0:i])
                     return G(p)
         return None
 
@@ -976,31 +1029,31 @@ class ContextExtraction:
         if isinstance(s, LoopIR.If):
             p = self.ctrlp_stmts(s.body)
             if p is not None:
-                return AAnd( lift_e(s.cond), p )
+                return AAnd(lift_e(s.cond), p)
             p = self.ctrlp_stmts(s.orelse)
             if p is not None:
-                return AAnd( ANot(lift_e(s.cond)), p )
+                return AAnd(ANot(lift_e(s.cond)), p)
             return None
         elif isinstance(s, LoopIR.Seq):
             p = self.ctrlp_stmts(s.body)
             if p is not None:
-                G   = self.loop_preenv(s)
-                bds = AAnd( AInt(0) <= AInt(s.iter),
-                            AInt(s.iter) < lift_e(s.hi) )
-                return AAnd( bds, G(p) )
+                G = self.loop_preenv(s)
+                bds = AAnd(AInt(0) <= AInt(s.iter),
+                           AInt(s.iter) < lift_e(s.hi))
+                return AAnd(bds, G(p))
             return None
         else:
             return None
 
     def preenv_stmts(self, stmts):
-        for i,s in enumerate(stmts):
+        for i, s in enumerate(stmts):
             if s is self.stmts[0]:
                 preG = AEnv()
             else:
                 preG = self.preenv_s(s)
 
-            if preG is not None: # found the focused sub-tree
-                G   = globenv(stmts[0:i])
+            if preG is not None:  # found the focused sub-tree
+                G = globenv(stmts[0:i])
                 return G + preG
         return None
 
@@ -1016,24 +1069,24 @@ class ContextExtraction:
         elif isinstance(s, LoopIR.Seq):
             preG = self.preenv_stmts(s.body)
             if preG is not None:
-                G   = self.loop_preenv(s)
+                G = self.loop_preenv(s)
                 return G + preG
             return None
         else:
             return None
 
     def posteff_stmts(self, stmts):
-        for i,s in enumerate(stmts):
+        for i, s in enumerate(stmts):
             if s is self.stmts[0]:
-                effs = [ E.BindEnv(globenv(self.stmts)) ]
-                post_stmts  = stmts[i+len(self.stmts):]
+                effs = [E.BindEnv(globenv(self.stmts))]
+                post_stmts = stmts[i + len(self.stmts):]
             else:
                 effs = self.posteff_s(s)
-                post_stmts  = stmts[i+1:]
+                post_stmts = stmts[i + 1:]
 
-            if effs is not None: # found the focused sub-tree
-                preG    = globenv(stmts[0:i])
-                return ([ E.BindEnv(preG) ] +
+            if effs is not None:  # found the focused sub-tree
+                preG = globenv(stmts[0:i])
+                return ([E.BindEnv(preG)] +
                         effs +
                         stmts_effs(post_stmts))
         return None
@@ -1042,10 +1095,10 @@ class ContextExtraction:
         if isinstance(s, LoopIR.If):
             effs = self.posteff_stmts(s.body)
             if effs is not None:
-                return [E.Guard( lift_e(s.cond), effs )]
+                return [E.Guard(lift_e(s.cond), effs)]
             effs = self.posteff_stmts(s.orelse)
             if effs is not None:
-                return [E.Guard( ANot(lift_e(s.cond)), effs )]
+                return [E.Guard(ANot(lift_e(s.cond)), effs)]
             return None
         elif isinstance(s, LoopIR.Seq):
             body = self.posteff_stmts(s.body)
@@ -1053,36 +1106,37 @@ class ContextExtraction:
                 return None
             else:
                 orig_hi = lift_e(s.hi)
-                hi_sym  = Sym('hi_tmp')
-                hi_env  = AEnv(hi_sym, orig_hi)
+                hi_sym = Sym('hi_tmp')
+                hi_env = AEnv(hi_sym, orig_hi)
 
-                bds     = AAnd( AInt(0) <= AInt(s.iter),
-                                AInt(s.iter) < AInt(hi_sym) )
+                bds = AAnd(AInt(0) <= AInt(s.iter),
+                           AInt(s.iter) < AInt(hi_sym))
                 bds_sym = Sym('bds_tmp')
-                hi_env  = hi_env + AEnv(bds_sym, bds)
+                hi_env = hi_env + AEnv(bds_sym, bds)
 
-                G       = self.loop_preenv(s)
+                G = self.loop_preenv(s)
 
                 guard_body = LoopIR.If(LoopIR.Read(bds_sym, [],
                                                    T.bool, s.srcinfo),
                                        s.body, [], None, s.srcinfo)
-                G_body  = globenv([guard_body])
-                return ([ E.BindEnv(hi_env),
-                          E.BindEnv(G),
-                          E.Guard( ABool(bds_sym), body ),
-                          E.BindEnv(G_body)
-                        ] + self.loop_posteff(s,
-                                LoopIR.Read(hi_sym, [],T.index, s.srcinfo)))
+                G_body = globenv([guard_body])
+                return ([E.BindEnv(hi_env),
+                         E.BindEnv(G),
+                         E.Guard(ABool(bds_sym), body),
+                         E.BindEnv(G_body)
+                         ] + self.loop_posteff(s,
+                                               LoopIR.Read(hi_sym, [], T.index,
+                                                           s.srcinfo)))
         else:
             return None
 
     def loop_preenv(self, s):
         assert isinstance(s, LoopIR.Seq)
-        old_i    = LoopIR.Read(s.iter, [], T.index, s.srcinfo)
-        new_i    = LoopIR.Read(s.iter.copy(), [], T.index, s.srcinfo)
-        pre_body = SubstArgs(s.body, { s.iter : new_i }).result()
-        pre_loop = LoopIR.Seq( new_i.name, old_i, pre_body,
-                               None, s.srcinfo)
+        old_i = LoopIR.Read(s.iter, [], T.index, s.srcinfo)
+        new_i = LoopIR.Read(s.iter.copy(), [], T.index, s.srcinfo)
+        pre_body = SubstArgs(s.body, {s.iter: new_i}).result()
+        pre_loop = LoopIR.Seq(new_i.name, old_i, pre_body,
+                              None, s.srcinfo)
         return globenv([pre_loop])
 
     def loop_posteff(self, s, hi):
@@ -1091,15 +1145,15 @@ class ContextExtraction:
         # but instead generate
         #   for x' in seq(0, hi-(x+1)): [x' -> x' + (x+1)]s
         assert isinstance(s, LoopIR.Seq)
-        old_i       = LoopIR.Read(s.iter, [], T.index, s.srcinfo)
-        new_i       = LoopIR.Read(s.iter.copy(), [], T.index, s.srcinfo)
-        old_plus1   = LoopIR.BinOp('+',old_i,LoopIR.Const(1,T.int,s.srcinfo),
-                                   T.index,s.srcinfo)
-        upper       = LoopIR.BinOp('-', hi, old_plus1, T.index, s.srcinfo)
-        shift_new   = LoopIR.BinOp('+', new_i, old_plus1, T.index, s.srcinfo)
-        post_body   = SubstArgs(s.body, { s.iter : shift_new }).result()
-        post_loop   = LoopIR.Seq( new_i.name, upper, post_body,
-                                  None, s.srcinfo)
+        old_i = LoopIR.Read(s.iter, [], T.index, s.srcinfo)
+        new_i = LoopIR.Read(s.iter.copy(), [], T.index, s.srcinfo)
+        old_plus1 = LoopIR.BinOp('+', old_i, LoopIR.Const(1, T.int, s.srcinfo),
+                                 T.index, s.srcinfo)
+        upper = LoopIR.BinOp('-', hi, old_plus1, T.index, s.srcinfo)
+        shift_new = LoopIR.BinOp('+', new_i, old_plus1, T.index, s.srcinfo)
+        post_body = SubstArgs(s.body, {s.iter: shift_new}).result()
+        post_loop = LoopIR.Seq(new_i.name, upper, post_body,
+                               None, s.srcinfo)
         return stmts_effs([post_loop])
 
 
@@ -1113,34 +1167,35 @@ def Commutes(a1, a2):
     W2, R2, Red2, All2 = getsets([ES.WRITE_ALL, ES.READ_ALL,
                                   ES.REDUCE, ES.ALL], a2)
 
-    pred = AAnd( ADef(is_empty(LIsct(W1, All2))),
-                 ADef(is_empty(LIsct(W2, All1))),
-                 ADef(is_empty(LIsct(Red1, R2))),
-                 ADef(is_empty(LIsct(Red2, R1))) )
+    pred = AAnd(ADef(is_empty(LIsct(W1, All2))),
+                ADef(is_empty(LIsct(W2, All1))),
+                ADef(is_empty(LIsct(Red1, R2))),
+                ADef(is_empty(LIsct(Red2, R1))))
 
     return pred
+
 
 def AllocCommutes(a1, a2):
-
     Alc1, All1 = getsets([ES.ALLOC, ES.ALL], a1)
     Alc2, All2 = getsets([ES.ALLOC, ES.ALL], a2)
-    pred = AAnd( ADef(is_empty(LIsct(Alc1, All2))),
-                 ADef(is_empty(LIsct(Alc2, All1))) )
+    pred = AAnd(ADef(is_empty(LIsct(Alc1, All2))),
+                ADef(is_empty(LIsct(Alc2, All1))))
     return pred
 
+
 def Shadows(a1, a2):
-    Alc1, Mod1              = getsets([ES.ALLOC, ES.MODIFY], a1)
-    Rd2, Wr2, Red2, All2    = getsets([ES.READ_ALL, ES.WRITE_ALL,
-                                       ES.REDUCE, ES.ALL], a2)
+    Alc1, Mod1 = getsets([ES.ALLOC, ES.MODIFY], a1)
+    Rd2, Wr2, Red2, All2 = getsets([ES.READ_ALL, ES.WRITE_ALL,
+                                    ES.REDUCE, ES.ALL], a2)
 
     # predicate via constituent conditions
-    alloc_is_dead   = ADef(is_empty(LIsct(Alc1,All2)))
-    mod_is_unread   = ADef(is_empty(LIsct(Mod1,LUnion(Rd2,Red2))))
-    mod_is_shadowed = ADef(is_empty(LDiff(Mod1,Wr2)))
+    alloc_is_dead = ADef(is_empty(LIsct(Alc1, All2)))
+    mod_is_unread = ADef(is_empty(LIsct(Mod1, LUnion(Rd2, Red2))))
+    mod_is_shadowed = ADef(is_empty(LDiff(Mod1, Wr2)))
 
-    pred            = AAnd(alloc_is_dead,
-                           mod_is_unread,
-                           mod_is_shadowed)
+    pred = AAnd(alloc_is_dead,
+                mod_is_unread,
+                mod_is_shadowed)
     return pred
 
 
@@ -1185,18 +1240,18 @@ class SchedulingError(Exception):
 def Check_ReorderStmts(proc, s1, s2):
     ctxt = ContextExtraction(proc, [s1, s2])
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
-    a1      = stmts_effs([s1])
-    a2      = stmts_effs([s2])
+    a1 = stmts_effs([s1])
+    a2 = stmts_effs([s2])
 
-    pred    = G(AAnd(Commutes(a1, a2), AllocCommutes(a1,a2)))
-    is_ok   = slv.verify(pred)
+    pred = G(AAnd(Commutes(a1, a2), AllocCommutes(a1, a2)))
+    is_ok = slv.verify(pred)
     slv.pop()
     if not is_ok:
         raise SchedulingError(
@@ -1206,44 +1261,44 @@ def Check_ReorderStmts(proc, s1, s2):
 def Check_ReorderLoops(proc, s):
     ctxt = ContextExtraction(proc, [s])
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
     assert len(s.body) == 1
     assert isinstance(s.body[0], LoopIR.Seq)
-    x_loop  = s
-    y_loop  = s.body[0]
-    body    = y_loop.body
-    x       = x_loop.iter
-    y       = y_loop.iter
-    x2      = x.copy()
-    y2      = y.copy()
-    subenv  = { x : LoopIR.Read(x2, [], T.index, null_srcinfo()),
-                y : LoopIR.Read(y2, [], T.index, null_srcinfo()) }
-    body2   = SubstArgs(body, subenv).result()
-    a_bd    = expr_effs(x_loop.hi) + expr_effs(y_loop.hi)
-    a       = stmts_effs(body)
-    a2      = stmts_effs(body2)
+    x_loop = s
+    y_loop = s.body[0]
+    body = y_loop.body
+    x = x_loop.iter
+    y = y_loop.iter
+    x2 = x.copy()
+    y2 = y.copy()
+    subenv = {x: LoopIR.Read(x2, [], T.index, null_srcinfo()),
+              y: LoopIR.Read(y2, [], T.index, null_srcinfo())}
+    body2 = SubstArgs(body, subenv).result()
+    a_bd = expr_effs(x_loop.hi) + expr_effs(y_loop.hi)
+    a = stmts_effs(body)
+    a2 = stmts_effs(body2)
 
-    def bds(x,hi):
+    def bds(x, hi):
         return AAnd(AInt(0) <= AInt(x), AInt(x) < lift_e(hi))
 
     reorder_is_safe = AAnd(
-        AForAll([x,y], AImplies(AMay(AAnd(bds(x,x_loop.hi),
-                                          bds(y,y_loop.hi))),
-                                Commutes(a_bd, a))),
-        AForAll([x,y,x2,y2],
-            AImplies(AMay(AAnd(bds(x,x_loop.hi), bds(y,y_loop.hi),
-                               bds(x2,x_loop.hi), bds(y2,y_loop.hi),
-                               AInt(x) < AInt(x2), AInt(y2) < AInt(y))),
-                Commutes(a,a2))))
+        AForAll([x, y], AImplies(AMay(AAnd(bds(x, x_loop.hi),
+                                           bds(y, y_loop.hi))),
+                                 Commutes(a_bd, a))),
+        AForAll([x, y, x2, y2],
+                AImplies(AMay(AAnd(bds(x, x_loop.hi), bds(y, y_loop.hi),
+                                   bds(x2, x_loop.hi), bds(y2, y_loop.hi),
+                                   AInt(x) < AInt(x2), AInt(y2) < AInt(y))),
+                         Commutes(a, a2))))
 
-    pred    = G(reorder_is_safe)
-    is_ok   = slv.verify(pred)
+    pred = G(reorder_is_safe)
+    is_ok = slv.verify(pred)
     slv.pop()
     if not is_ok:
         raise SchedulingError(
@@ -1260,69 +1315,68 @@ def Check_ReorderLoops(proc, s):
 #                     Commutes(a1', a2) /\ AllocCommutes(a1, a2) )
 #
 def Check_FissionLoop(proc, loop, stmts1, stmts2):
-    ctxt    = ContextExtraction(proc, [loop])
+    ctxt = ContextExtraction(proc, [loop])
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
     assert isinstance(loop, LoopIR.Seq)
-    i       = loop.iter
-    j       = i.copy()
-    hi      = loop.hi
-    subenv  = { i : LoopIR.Read(j, [], T.index, null_srcinfo()) }
-    stmts1_j= SubstArgs(stmts1, subenv).result()
+    i = loop.iter
+    j = i.copy()
+    hi = loop.hi
+    subenv = {i: LoopIR.Read(j, [], T.index, null_srcinfo())}
+    stmts1_j = SubstArgs(stmts1, subenv).result()
 
-    a_bd    = expr_effs(hi)
-    a1      = stmts_effs(stmts1)
-    a1_j    = stmts_effs(stmts1_j)
-    a2      = stmts_effs(stmts2)
+    a_bd = expr_effs(hi)
+    a1 = stmts_effs(stmts1)
+    a1_j = stmts_effs(stmts1_j)
+    a2 = stmts_effs(stmts2)
 
-    def bds(x,hi):
+    def bds(x, hi):
         return AAnd(AInt(0) <= AInt(x), AInt(x) < lift_e(hi))
 
     no_bound_change = (
-        AForAll([i], AImplies( AMay(bds(i,hi)),
-            AAnd(Commutes(a_bd, a1), Commutes(a_bd, a2))  )))
+        AForAll([i], AImplies(AMay(bds(i, hi)),
+                              AAnd(Commutes(a_bd, a1), Commutes(a_bd, a2)))))
     stmts_commute = (
-        AForAll([i,j], AImplies( AMay(AAnd( bds(i,hi), bds(j,hi),
-                                            AInt(i) < AInt(j) )),
+        AForAll([i, j], AImplies(AMay(AAnd(bds(i, hi), bds(j, hi),
+                                           AInt(i) < AInt(j))),
                                  AAnd(Commutes(a1_j, a2),
-                                      AllocCommutes(a1, a2)) )))
+                                      AllocCommutes(a1, a2)))))
 
-    pred    = G(AAnd(no_bound_change, stmts_commute))
-    is_ok   = slv.verify(pred)
+    pred = G(AAnd(no_bound_change, stmts_commute))
+    is_ok = slv.verify(pred)
     slv.pop()
     if not is_ok:
         raise SchedulingError(
             f"Cannot fission loop over {i} at {loop.srcinfo}.")
 
 
-
 def Check_DeleteConfigWrite(proc, stmts):
     assert len(stmts) > 0
     ctxt = ContextExtraction(proc, stmts)
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
-    ap      = ctxt.get_posteffs()
-    a       = G(stmts_effs(stmts))
-    stmtsG  = globenv(stmts)
-    
-    slv     = SMTSolver(verbose=False)
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
+    ap = ctxt.get_posteffs()
+    a = G(stmts_effs(stmts))
+    stmtsG = globenv(stmts)
+
+    slv = SMTSolver(verbose=False)
     slv.push()
-    a       = [E.Guard(AMay(p), a)]
+    a = [E.Guard(AMay(p), a)]
 
     # extract effects
-    WrG, Mod    = getsets([ES.WRITE_G, ES.MODIFY], a)
-    WrGp, RdGp  = getsets([ES.WRITE_G, ES.READ_G], ap)
+    WrG, Mod = getsets([ES.WRITE_G, ES.MODIFY], a)
+    WrGp, RdGp = getsets([ES.WRITE_G, ES.READ_G], ap)
 
     # check that `stmts` does not modify any non-global data
-    only_mod_glob   = ADef(is_empty(LDiff(Mod,WrG)))
-    is_ok           = slv.verify(only_mod_glob)
+    only_mod_glob = ADef(is_empty(LDiff(Mod, WrG)))
+    is_ok = slv.verify(only_mod_glob)
     if not is_ok:
         slv.pop()
         raise SchedulingError(
@@ -1333,25 +1387,26 @@ def Check_DeleteConfigWrite(proc, stmts):
     # the statement block being focused on.  Filter out any
     # such configuration variables whose values are definitely unchanged
     def is_cfg_unmod_by_stmts(pt):
-        pt_e    = ABool(pt.name) if pt.typ == T.bool else AInt(pt.name)
-        #cfg_unwritten = ADef( ANot(is_elem(pt, WrG)) )
-        cfg_unchanged = ADef( G(AEq(pt_e, stmtsG(pt_e))) )
+        pt_e = ABool(pt.name) if pt.typ == T.bool else AInt(pt.name)
+        # cfg_unwritten = ADef( ANot(is_elem(pt, WrG)) )
+        cfg_unchanged = ADef(G(AEq(pt_e, stmtsG(pt_e))))
         return slv.verify(cfg_unchanged)
-    cfg_mod = { pt.name : pt for pt in get_point_exprs(WrG)
-                             if not is_cfg_unmod_by_stmts(pt) }
+
+    cfg_mod = {pt.name: pt for pt in get_point_exprs(WrG)
+               if not is_cfg_unmod_by_stmts(pt)}
 
     # consider every global that might be modified
     cfg_mod_visible = set()
-    for _,pt in cfg_mod.items():
-        pt_e    = ABool(pt.name) if pt.typ == T.bool else AInt(pt.name)
-        is_written      = is_elem(pt, WrG)
-        is_unchanged    = G(AEq(pt_e, stmtsG(pt_e)))
-        is_read_post    = is_elem(pt, RdGp)
-        is_overwritten  = is_elem(pt, WrGp)
+    for _, pt in cfg_mod.items():
+        pt_e = ABool(pt.name) if pt.typ == T.bool else AInt(pt.name)
+        is_written = is_elem(pt, WrG)
+        is_unchanged = G(AEq(pt_e, stmtsG(pt_e)))
+        is_read_post = is_elem(pt, RdGp)
+        is_overwritten = is_elem(pt, WrGp)
 
         # if the value of the global might be read,
         # then it must not have been changed.
-        safe_write  = AImplies( AMay(is_read_post), ADef(is_unchanged) )
+        safe_write = AImplies(AMay(is_read_post), ADef(is_unchanged))
         if not slv.verify(safe_write):
             slv.pop()
             raise SchedulingError(
@@ -1360,9 +1415,9 @@ def Check_DeleteConfigWrite(proc, stmts):
                 f"values might be read later in this procedure")
         # the write is invisible if its definitely unchanged or definitely
         # overwritten
-        invisible   = ADef( AOr( is_unchanged, is_overwritten ) )
+        invisible = ADef(AOr(is_unchanged, is_overwritten))
         if not slv.verify(invisible):
-            cfg_mod_visible.add( pt.name )
+            cfg_mod_visible.add(pt.name)
 
     slv.pop()
     return cfg_mod_visible
@@ -1378,36 +1433,37 @@ def Check_ExtendEqv(proc, stmts0, stmts1, cfg_mod):
     assert len(stmts1) > 0
     ctxt = ContextExtraction(proc, stmts0)
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
-    ap      = ctxt.get_posteffs()
-    #a       = G(stmts_effs(stmts))
-    sG0     = globenv(stmts0)
-    sG1     = globenv(stmts1)
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
+    ap = ctxt.get_posteffs()
+    # a       = G(stmts_effs(stmts))
+    sG0 = globenv(stmts0)
+    sG1 = globenv(stmts1)
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
-    #slv.assume(AMay(p))
+    # slv.assume(AMay(p))
 
     # extract effects
-    #WrG, Mod    = getsets([ES.WRITE_G, ES.MODIFY], a)
-    WrGp, RdGp  = getsets([ES.WRITE_G, ES.READ_G], ap)
+    # WrG, Mod    = getsets([ES.WRITE_G, ES.MODIFY], a)
+    WrGp, RdGp = getsets([ES.WRITE_G, ES.READ_G], ap)
 
     # check that none of the configuration variables which might have
     # changed are being observed.
     def make_point(key):
-        cfg, fld    = reverse_config_lookup(key)
-        typ         = cfg.lookup(fld)[1]
+        cfg, fld = reverse_config_lookup(key)
+        typ = cfg.lookup(fld)[1]
         return APoint(key, [], typ)
-    cfg_mod_pts = [ make_point(key) for key in cfg_mod ]
+
+    cfg_mod_pts = [make_point(key) for key in cfg_mod]
     cfg_mod_visible = set()
     for pt in cfg_mod_pts:
         pt_e = ABool(pt.name) if pt.typ == T.bool else AInt(pt.name)
-        is_unchanged    = AImplies(p, G(AEq(sG0(pt_e), sG1(pt_e))))
-        is_read_post    = is_elem(pt, RdGp)
-        is_overwritten  = is_elem(pt, WrGp)
+        is_unchanged = AImplies(p, G(AEq(sG0(pt_e), sG1(pt_e))))
+        is_read_post = is_elem(pt, RdGp)
+        is_overwritten = is_elem(pt, WrGp)
 
-        safe_write  = AImplies( AMay(is_read_post), ADef(is_unchanged) )
+        safe_write = AImplies(AMay(is_read_post), ADef(is_unchanged))
         if not slv.verify(safe_write):
             slv.pop()
             raise SchedulingError(
@@ -1415,89 +1471,93 @@ def Check_ExtendEqv(proc, stmts0, stmts1, cfg_mod):
                 f"configuration field {pt.name} might be read "
                 f"subsequently")
 
-        shadowed        = ADef( is_overwritten )
+        shadowed = ADef(is_overwritten)
         if not slv.verify(shadowed):
             cfg_mod_visible.add(pt.name)
 
     slv.pop()
     return cfg_mod_visible
 
+
 def Check_ExprEqvInContext(proc, stmts, expr0, expr1):
     assert len(stmts) > 0
     ctxt = ContextExtraction(proc, stmts)
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
     e0 = lift_e(expr0)
     e1 = lift_e(expr1)
 
-    test    = G(AEq(e0, e1))
-    is_ok   = slv.verify(test)
+    test = G(AEq(e0, e1))
+    is_ok = slv.verify(test)
     slv.pop()
     if not is_ok:
         raise SchedulingError(
             f"Expressions are not equivalent:\n{expr0}\nvs.\n{expr1}")
 
+
 def Check_BufferRW(proc, stmts, buf, ndim):
     assert len(stmts) > 0
     ctxt = ContextExtraction(proc, stmts)
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
-    wholebuf    = LS.WholeBuf(buf, ndim)
-    a           = G(stmts_effs(stmts))
+    wholebuf = LS.WholeBuf(buf, ndim)
+    a = G(stmts_effs(stmts))
     Mod, Rd, Red = getsets([ES.MODIFY, ES.READ_H, ES.REDUCE], a)
-    write       = LIsct(wholebuf, Mod)
-    read        = LIsct(wholebuf, LUnion(Rd,Red))
+    write = LIsct(wholebuf, Mod)
+    read = LIsct(wholebuf, LUnion(Rd, Red))
 
-    no_read     = slv.verify(ADef(is_empty(read)))
-    no_write    = slv.verify(ADef(is_empty(write)))
+    no_read = slv.verify(ADef(is_empty(read)))
+    no_write = slv.verify(ADef(is_empty(write)))
     slv.pop()
 
     return (not no_read), (not no_write)
+
 
 def Check_BufferReduceOnly(proc, stmts, buf, ndim):
     assert len(stmts) > 0
     ctxt = ContextExtraction(proc, stmts)
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
-    wholebuf    = LS.WholeBuf(buf, ndim)
-    a           = G(stmts_effs(stmts))
-    RW          = getsets([ES.READ_WRITE], a)[0]
-    readwrite   = LIsct(wholebuf, RW)
+    wholebuf = LS.WholeBuf(buf, ndim)
+    a = G(stmts_effs(stmts))
+    RW = getsets([ES.READ_WRITE], a)[0]
+    readwrite = LIsct(wholebuf, RW)
 
-    no_rw       = slv.verify(ADef(is_empty(readwrite)))
+    no_rw = slv.verify(ADef(is_empty(readwrite)))
     slv.pop()
     if not no_rw:
         raise SchedulingError(
             f"The buffer {buf} is accessed in a way other than "
             f"simply reducing into it")
 
+
 def Check_Bounds(proc, alloc_stmt, block):
     if len(block) == 0:
         return
-    ctxt    = ContextExtraction(proc, block)
+    ctxt = ContextExtraction(proc, block)
 
-    p       = ctxt.get_control_predicate()
-    G       = ctxt.get_pre_globenv()
+    p = ctxt.get_control_predicate()
+    G = ctxt.get_pre_globenv()
 
-    slv     = SMTSolver(verbose=False)
+    slv = SMTSolver(verbose=False)
     slv.push()
     slv.assume(AMay(p))
 
@@ -1508,20 +1568,20 @@ def Check_Bounds(proc, alloc_stmt, block):
         alloc_set = LS.Point(alloc_stmt.name, [],
                              alloc_stmt.type.basetype())
     else:
-        coords      = [ Sym(f"i{i}") for i,_ in enumerate(shape) ]
-        bounds      = AAnd(*[ AAnd( AInt(0) <= AInt(i),
-                                    AInt(i) <  lift_e(n) )
-                              for i,n in zip(coords,shape) ])
-        pt          = LS.Point(alloc_stmt.name, [ AInt(i) for i in coords ],
-                               alloc_stmt.type.basetype())
-        alloc_set   = LFilter(bounds, pt)
+        coords = [Sym(f"i{i}") for i, _ in enumerate(shape)]
+        bounds = AAnd(*[AAnd(AInt(0) <= AInt(i),
+                             AInt(i) < lift_e(n))
+                        for i, n in zip(coords, shape)])
+        pt = LS.Point(alloc_stmt.name, [AInt(i) for i in coords],
+                      alloc_stmt.type.basetype())
+        alloc_set = LFilter(bounds, pt)
         for i in reversed(coords):
             alloc_set = LBigUnion(i, alloc_set)
 
-    a       = G(stmts_effs(block))
-    All     = getsets([ES.ALL], a)[0]
+    a = G(stmts_effs(block))
+    All = getsets([ES.ALL], a)[0]
     All_inbuf = LIsct(All, LS.WholeBuf(alloc_stmt.name, len(shape)))
-    is_ok   = slv.verify( ADef(is_empty(LDiff(All_inbuf,alloc_set))) )
+    is_ok = slv.verify(ADef(is_empty(LDiff(All_inbuf, alloc_set))))
     slv.pop()
     if not is_ok:
         raise SchedulingError(

--- a/src/exo/prec_analysis.py
+++ b/src/exo/prec_analysis.py
@@ -81,6 +81,8 @@ class PrecisionAnalysis(LoopIR_Rewrite):
         # in a post-traversal sort of way below
         # before returning
         result  = super().map_s(s)
+        if result is None:
+            result = [s]
         styp    = type(s)
 
         if styp is LoopIR.Call:

--- a/src/exo/prec_analysis.py
+++ b/src/exo/prec_analysis.py
@@ -156,7 +156,7 @@ class PrecisionAnalysis(LoopIR_Rewrite):
             return LoopIR.WindowExpr(e.name, e.idx, wtyp, e.srcinfo)
 
         elif isinstance(e, LoopIR.USub):
-            arg = self.map_e(e.arg)
+            arg = self.apply_e(e.arg)
 
             if not e.type.is_numeric():
                 return LoopIR.USub(arg, e.type, e.srcinfo)
@@ -165,8 +165,8 @@ class PrecisionAnalysis(LoopIR_Rewrite):
             return LoopIR.USub(arg, arg.type, e.srcinfo)
 
         elif isinstance(e, LoopIR.BinOp):
-            lhs = self.map_e(e.lhs)
-            rhs = self.map_e(e.rhs)
+            lhs = self.apply_e(e.lhs)
+            rhs = self.apply_e(e.rhs)
 
             # first let's get the index expressions
             # and booleans out of the way

--- a/src/exo/prec_analysis.py
+++ b/src/exo/prec_analysis.py
@@ -5,19 +5,22 @@ from .LoopIR import LoopIR, LoopIR_Rewrite, T
 # Default Precision Management
 
 _default_prec = T.f32
+
+
 def set_default_prec(name):
     global _default_prec
     vals = {
-        'f32'   : T.f32,
-        'f64'   : T.f64,
-        'i8'    : T.i8,
-        'i32'   : T.i32,
+        'f32': T.f32,
+        'f64': T.f64,
+        'i8': T.i8,
+        'i32': T.i32,
     }
     if name not in vals:
         raise TypeError(f"Got {name}, but "
                         "expected one of the following precision types: " +
                         ','.join([k for k in vals]))
     _default_prec = vals[name]
+
 
 def get_default_prec():
     return _default_prec
@@ -31,9 +34,9 @@ def get_default_prec():
 class PrecisionAnalysis(LoopIR_Rewrite):
     def __init__(self, proc):
         assert isinstance(proc, LoopIR.proc)
-        self._errors    = []
-        self._types     = {}
-        self.default    = get_default_prec()
+        self._errors = []
+        self._types = {}
+        self.default = get_default_prec()
 
         super().__init__(proc)
 
@@ -47,6 +50,7 @@ class PrecisionAnalysis(LoopIR_Rewrite):
     def set_type(self, name, typ):
         assert name not in self._types
         self._types[name] = typ
+
     def get_type(self, name, default=None):
         if name not in self._types and default is not None:
             return default
@@ -80,10 +84,10 @@ class PrecisionAnalysis(LoopIR_Rewrite):
         # and then possibly patch up the results
         # in a post-traversal sort of way below
         # before returning
-        result  = super().map_s(s)
+        result = super().map_s(s)
         if result is None:
             result = [s]
-        styp    = type(s)
+        styp = type(s)
 
         if styp is LoopIR.Call:
             assert len(result) == 1
@@ -91,9 +95,9 @@ class PrecisionAnalysis(LoopIR_Rewrite):
             # check call arguments for precision consistency...
             args = result[0].args
             for call_a, sig_a in zip(args, s.f.args):
-                ct  = call_a.type.basetype()
-                st  = sig_a.type.basetype()
-                st  = self.default if st == T.R else st
+                ct = call_a.type.basetype()
+                st = sig_a.type.basetype()
+                st = self.default if st == T.R else st
                 if st.is_numeric() and st != ct:
                     self.err(call_a, f"expected precision {st}, but got {ct}")
 
@@ -194,7 +198,6 @@ class PrecisionAnalysis(LoopIR_Rewrite):
                 typ = lhs.type
             return LoopIR.BinOp(e.op, lhs, rhs, typ, e.srcinfo)
 
-
         return super().map_e(e)
 
     # this routine allows for us to retro-actively
@@ -225,7 +228,8 @@ class PrecisionAnalysis(LoopIR_Rewrite):
 
     # make this more efficient by not rewriting
     # most of the sub-trees
-    def map_t(self,t):
+    def map_t(self, t):
         return t
-    def map_eff(self,eff):
+
+    def map_eff(self, eff):
         return eff

--- a/src/exo/prec_analysis.py
+++ b/src/exo/prec_analysis.py
@@ -87,9 +87,7 @@ class PrecisionAnalysis(LoopIR_Rewrite):
         result = super().map_s(s)
         if result is None:
             result = [s]
-        styp = type(s)
-
-        if styp is LoopIR.Call:
+        if isinstance(s, LoopIR.Call):
             assert len(result) == 1
 
             # check call arguments for precision consistency...
@@ -101,7 +99,7 @@ class PrecisionAnalysis(LoopIR_Rewrite):
                 if st.is_numeric() and st != ct:
                     self.err(call_a, f"expected precision {st}, but got {ct}")
 
-        elif styp is LoopIR.Assign or styp is LoopIR.Reduce:
+        elif isinstance(s, (LoopIR.Assign, LoopIR.Reduce)):
             rtyp = result[0].rhs.type
             ltyp = self.get_type(s.name).basetype()
             assert ltyp != T.err and ltyp != T.R
@@ -122,7 +120,7 @@ class PrecisionAnalysis(LoopIR_Rewrite):
                     # then we have an implicit cast at this point
                     result[0] = result[0].update(cast="yup, cast!")
 
-        elif styp is LoopIR.WriteConfig:
+        elif isinstance(s, LoopIR.WriteConfig):
             rtyp = result[0].rhs.type
             ltyp = s.config.lookup(s.field)[1]
             assert ltyp != T.err and ltyp != T.R
@@ -133,11 +131,11 @@ class PrecisionAnalysis(LoopIR_Rewrite):
                     result[0] = result[0].update(
                         rhs=self.coerce_e(result[0].rhs, ltyp))
 
-        elif styp is LoopIR.WindowStmt:
+        elif isinstance(s, LoopIR.WindowStmt):
             # update the type binding for this symbol...
             self.set_type(result[0].lhs, result[0].rhs.type)
 
-        elif styp is LoopIR.Alloc:
+        elif isinstance(s, LoopIR.Alloc):
             typ = result[0].type
             if s.type.basetype() == T.R:
                 typ = self.splice_type(s.type, self.default)
@@ -229,7 +227,7 @@ class PrecisionAnalysis(LoopIR_Rewrite):
     # make this more efficient by not rewriting
     # most of the sub-trees
     def map_t(self, t):
-        return t
+        return None
 
     def map_eff(self, eff):
-        return eff
+        return None

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -923,8 +923,7 @@ def test_lift_if_second_statement_in_then_error():
                     x[i] = 2.0
 
     with pytest.raises(SchedulingError,
-                       match='expected if statement to be directly nested in '
-                             'parents'):
+                       match='expected if statement to be directly nested in parents'):
         foo = lift_if(foo, 'if i < 10: _')
         print(foo)
 
@@ -941,8 +940,7 @@ def test_lift_if_second_statement_in_else_error():
                     x[i] = 2.0
 
     with pytest.raises(SchedulingError,
-                       match='expected if statement to be directly nested in '
-                             'parents'):
+                       match='expected if statement to be directly nested in parents'):
         foo = lift_if(foo, 'if i < 10: _')
         print(foo)
 
@@ -956,8 +954,7 @@ def test_lift_if_second_statement_in_for_error():
                 pass
 
     with pytest.raises(SchedulingError,
-                       match='expected if statement to be directly nested in '
-                             'parents'):
+                       match='expected if statement to be directly nested in parents'):
         foo = lift_if(foo, 'if m > 12: _')
         print(foo)
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -2,20 +2,23 @@ from __future__ import annotations
 
 import pytest
 
-from exo import proc, DRAM, SchedulingError, Procedure
-from exo.libs.memories import GEMM_SCRATCH
 from exo import ParseFragmentError
+from exo import proc, DRAM, Procedure
+from exo.libs.memories import GEMM_SCRATCH
 from exo.stdlib.scheduling import *
+
 
 def test_commute(golden):
     @proc
-    def foo(x : R[3], y : R[3], z : R):
-        z = x[0]*y[2]
+    def foo(x: R[3], y: R[3], z: R):
+        z = x[0] * y[2]
+
     assert str(commute_expr(foo, 'x[0] * y[_]')) == golden
+
 
 def test_commute2():
     @proc
-    def foo(x : R[3], y : R[3], z : R):
+    def foo(x: R[3], y: R[3], z: R):
         z = x[0] + y[0] + x[1] + y[1]
 
     with pytest.raises(SchedulingError, match='failed to find matches'):
@@ -24,15 +27,18 @@ def test_commute2():
         # I think pattern matching should be powerful to find this.
         commute_expr(foo, 'y[0] + x[1]')
 
+
 def test_commute3(golden):
     @proc
-    def foo(x : R[3], y : R[3], z : R):
+    def foo(x: R[3], y: R[3], z: R):
         z = (x[0] + y[0]) * (x[1] + y[1] + y[2])
+
     assert str(commute_expr(foo, '(x[_] + y[_]) * (x[_] + y[_] + y[_])')) == golden
+
 
 def test_commute4():
     @proc
-    def foo(x : R[3], y : R[3], z : R):
+    def foo(x: R[3], y: R[3], z: R):
         z = x[0] - y[2]
 
     with pytest.raises(TypeError, match="can commute"):
@@ -41,67 +47,70 @@ def test_commute4():
 
 def test_product_loop(golden):
     @proc
-    def foo(n : size):
-        x : R[n, 30]
+    def foo(n: size):
+        x: R[n, 30]
         for i in seq(0, n):
             for j in seq(0, 30):
-                x[i,j] = 0.0
+                x[i, j] = 0.0
 
     assert str(mult_loops(foo, 'i j', 'ij')) == golden
+
 
 def test_product_loop2(golden):
     @proc
-    def foo(n : size, x : R[n, 30]):
+    def foo(n: size, x: R[n, 30]):
         for i in seq(0, n):
             for j in seq(0, 30):
-                x[i,j] = 0.0
+                x[i, j] = 0.0
 
     assert str(mult_loops(foo, 'i j', 'ij')) == golden
 
+
 def test_product_loop3():
     @proc
-    def foo(n : size, m : size):
-        x : R[n, m]
+    def foo(n: size, m: size):
+        x: R[n, m]
         for i in seq(0, n):
             for j in seq(0, m):
-                x[i,j] = 0.0
+                x[i, j] = 0.0
 
     with pytest.raises(SchedulingError,
-            match='expected the inner loop to have a constant bound'):
+                       match='expected the inner loop to have a constant bound'):
         mult_loops(foo, 'i j', 'ij')
+
 
 def test_product_loop4(golden):
     @proc
-    def foo(n : size, x : R[n]):
+    def foo(n: size, x: R[n]):
         for i in seq(0, n):
             for j in seq(0, 30):
                 x[i] = 0.0
 
     assert str(mult_loops(foo, 'i j', 'ij')) == golden
 
+
 def test_product_loop5(golden):
     @proc
-    def foo(n : size, m : size, x : R[n, 100]):
+    def foo(n: size, m: size, x: R[n, 100]):
         assert m < n
         x2 = x[0:m, 0:30]
         for i in seq(0, m):
             for j in seq(0, 30):
-                x2[i,j] = 0.0
+                x2[i, j] = 0.0
 
     assert str(mult_loops(foo, 'i j', 'ij')) == golden
 
 
-
 def test_delete_pass(golden):
     @proc
-    def foo(x : R):
+    def foo(x: R):
         pass
         x = 0.0
 
     assert str(delete_pass(foo)) == golden
 
     @proc
-    def foo(x : R):
+    def foo(x: R):
         for i in seq(0, 16):
             for j in seq(0, 2):
                 pass
@@ -109,45 +118,50 @@ def test_delete_pass(golden):
 
     assert str(delete_pass(foo)) == golden
 
+
 def test_add_loop1(golden):
     @proc
     def foo():
-        x : R
+        x: R
         x = 0.0
 
     assert str(add_loop(foo, 'x = _', 'i', 10)) == golden
 
+
 def test_add_loop2(golden):
     @proc
     def foo():
-        x : R
+        x: R
         x = 0.0
 
     assert str(add_loop(foo, 'x = _', 'i', 10, guard=True)) == golden
 
+
 def test_add_loop3():
     @proc
     def foo():
-        x : R
+        x: R
         x = 0.0
 
     with pytest.raises(TypeError, match='expected a bool'):
         add_loop(foo, 'x = _', 'i', 10, guard=100)
 
+
 def test_add_loop4(golden):
     @proc
-    def foo(n : size, m : size):
-        x : R
+    def foo(n: size, m: size):
+        x: R
         x = 0.0
 
     assert str(add_loop(foo, 'x = _', 'i', 'n+m', guard=True)) == golden
+
 
 # Should fix this test with program analysis
 @pytest.mark.skip
 def test_add_loop5():
     @proc
-    def foo(n : size, m : size):
-        x : R
+    def foo(n: size, m: size):
+        x: R
         x = 0.0
 
     with pytest.raises(Exception, match='bound expression should be positive'):
@@ -176,19 +190,21 @@ def test_proc_equal():
     # considered equal.
     assert foo != make_foo()
 
+
 def test_simplify3(golden):
     @proc
-    def foo(n : size, m : size):
+    def foo(n: size, m: size):
         assert m == 1 and n == 1
-        y : R[10]
-        y[10*m - 10*n + 2*n] = 2.0
+        y: R[10]
+        y[10 * m - 10 * n + 2 * n] = 2.0
 
     assert str(simplify(foo)) == golden
+
 
 def test_simplify2(golden):
     @proc
     def foo(A: i8[32, 64] @ DRAM, B: i8[16, 128] @ DRAM,
-            C: i32[32, 32] @ DRAM, ko : size, ji_unroll : size, ii_unroll : size):
+            C: i32[32, 32] @ DRAM, ko: size, ji_unroll: size, ii_unroll: size):
         for io in seq(0, 1):
             for jo in seq(0, 1):
                 Btile1: i8[16 * (ko + 1) - 16 * ko, 128 * jo + 64 *
@@ -206,28 +222,31 @@ def test_simplify2(golden):
 
     assert str(simplify(foo)) == golden
 
+
 def test_simplify(golden):
     @proc
-    def foo(n : size, m : size):
-        x : R[n, 16 * (n + 1) - n * 16, (10 + 2) * m - m * 12 + 10]
+    def foo(n: size, m: size):
+        x: R[n, 16 * (n + 1) - n * 16, (10 + 2) * m - m * 12 + 10]
         for i in seq(0, 4 * (n + 2) - n * 4 + n * 5):
             pass
-        y : R[10]
-        y[n*4 - n*4 + 1] = 0.0
+        y: R[10]
+        y[n * 4 - n * 4 + 1] = 0.0
 
     assert str(simplify(foo)) == golden
 
+
 def test_pattern_match():
     @proc
-    def foo(N1 : size, M1 : size, K1 : size, N2: size, M2: size, K2: size):
-        x : R[N1, M1, K1]
-        x : R[N2, M2, K2]
+    def foo(N1: size, M1: size, K1: size, N2: size, M2: size, K2: size):
+        x: R[N1, M1, K1]
+        x: R[N2, M2, K2]
 
-    res1 = rearrange_dim(foo, 'x : _', [2,1,0])
-    res1 = rearrange_dim(res1, 'x : _ #1', [2,1,0])
-    res2 = rearrange_dim(foo, 'x : R[N1, M1, K1]', [2,1,0])
+    res1 = rearrange_dim(foo, 'x : _', [2, 1, 0])
+    res1 = rearrange_dim(res1, 'x : _ #1', [2, 1, 0])
+    res2 = rearrange_dim(foo, 'x : R[N1, M1, K1]', [2, 1, 0])
 
     assert str(res1) != str(res2)
+
 
 def test_fission_after_simple(golden):
     @proc
@@ -286,10 +305,10 @@ def test_rearrange_dim(golden):
                 for k in seq(0, K):
                     a[m, k, n] = x[n, m, k]
 
-    foo = rearrange_dim(foo, 'a : i8[_]', [1,2,0])
+    foo = rearrange_dim(foo, 'a : i8[_]', [1, 2, 0])
     bar = rearrange_dim(bar, 'a : i8[_]', [1, 0, 2])
     bar = rearrange_dim(bar, 'a : i8[_] #1', [1, 0, 2])
-    cases = [ foo, bar ]
+    cases = [foo, bar]
 
     assert '\n'.join(map(str, cases)) == golden
 
@@ -453,16 +472,17 @@ def test_expand_dim5(golden):
     @proc
     def foo(n: size, x: i8):
         for i in seq(0, n):
-            a : i8
+            a: i8
             a = x
 
     foo = expand_dim(foo, 'a : i8', 'n', 'i')
     assert str(foo) == golden
 
+
 def test_divide_dim_1(golden):
     @proc
-    def foo(n: size, m: size, A : R[n + m + 12]):
-        x : R[n, 12, m]
+    def foo(n: size, m: size, A: R[n + m + 12]):
+        x: R[n, 12, m]
         for i in seq(0, n):
             for j in seq(0, 12):
                 for k in seq(0, m):
@@ -474,8 +494,8 @@ def test_divide_dim_1(golden):
 
 def test_divide_dim_fail_1():
     @proc
-    def foo(n: size, m: size, A : R[n + m + 12]):
-        x : R[n, 12, m]
+    def foo(n: size, m: size, A: R[n + m + 12]):
+        x: R[n, 12, m]
         for i in seq(0, n):
             for j in seq(0, 12):
                 for k in seq(0, m):
@@ -487,10 +507,11 @@ def test_divide_dim_fail_1():
     with pytest.raises(SchedulingError, match='Cannot divide 12 evenly'):
         divide_dim(foo, 'x', 1, 5)
 
+
 def test_mult_dim_1(golden):
     @proc
-    def foo(n: size, m: size, A : R[n + m + 12]):
-        x : R[n, m, 4]
+    def foo(n: size, m: size, A: R[n + m + 12]):
+        x: R[n, m, 4]
         for i in seq(0, n):
             for j in seq(0, m):
                 for k in seq(0, 4):
@@ -499,10 +520,11 @@ def test_mult_dim_1(golden):
     foo = mult_dim(foo, 'x', 0, 2)
     assert str(foo) == golden
 
+
 def test_mult_dim_fail_1():
     @proc
-    def foo(n: size, m: size, A : R[n + m + 12]):
-        x : R[n, m, 4]
+    def foo(n: size, m: size, A: R[n + m + 12]):
+        x: R[n, m, 4]
         for i in seq(0, n):
             for j in seq(0, m):
                 for k in seq(0, 4):
@@ -517,6 +539,7 @@ def test_mult_dim_fail_1():
     with pytest.raises(SchedulingError,
                        match='Cannot multiply with non-literal'):
         mult_dim(foo, 'x', 0, 1)
+
 
 def test_double_fission(golden):
     @proc
@@ -669,9 +692,9 @@ def test_simple_bind_expr(golden):
 def test_bind_expr_diff_indices(golden):
     @proc
     def bar(n: size, x: i8[n], y: i8[n], z: i8[n]):
-        for i in seq(0, n-1):
-            w : i8[n]
-            w[i+1] = x[i] + y[i]
+        for i in seq(0, n - 1):
+            w: i8[n]
+            w[i + 1] = x[i] + y[i]
             w[i] = x[i] + y[i]
             z[i] = w[i]
 
@@ -755,7 +778,8 @@ def test_lift(golden):
             for k in seq(0, 16):
                 a[k] = A[k, i]
 
-    bar = autolift_alloc(bar, 'a: i8[_]', n_lifts=1, mode='col', size=20, keep_dims=True)
+    bar = autolift_alloc(bar, 'a: i8[_]', n_lifts=1, mode='col', size=20,
+                         keep_dims=True)
     assert str(bar) == golden
 
 
@@ -1129,72 +1153,78 @@ def test_lift_if_in_full_nest(golden):
 
     foo = lift_if(foo, 'if n < 20: _')
     assert str(foo) == golden
-                
+
 
 def test_stage_mem(golden):
     # This test stages a buffer being accumulated in
     # on a per-tile basis
     @proc
-    def sqmat(n : size, A : R[n,n], B : R[n,n]):
+    def sqmat(n: size, A: R[n, n], B: R[n, n]):
         assert n % 4 == 0
-        for i in seq(0,n/4):
-            for j in seq(0,n/4):
-                for k in seq(0,n/4):
-                    for ii in seq(0,4):
-                        for jj in seq(0,4):
-                            for kk in seq(0,4):
-                                A[4*i+ii,4*j+jj] += ( B[4*i+ii,4*k+kk] *
-                                                      B[4*k+kk,4*j+jj] )
+        for i in seq(0, n / 4):
+            for j in seq(0, n / 4):
+                for k in seq(0, n / 4):
+                    for ii in seq(0, 4):
+                        for jj in seq(0, 4):
+                            for kk in seq(0, 4):
+                                A[4 * i + ii, 4 * j + jj] += (
+                                            B[4 * i + ii, 4 * k + kk] *
+                                            B[4 * k + kk, 4 * j + jj])
 
     sqmat = stage_mem(sqmat, 'for k in _: _',
                              'A[4*i:4*i+4, 4*j:4*j+4]', 'Atile')
     assert str(simplify(sqmat)) == golden
 
+
 def test_stage_mem_point(golden):
     @proc
-    def matmul(n : size, A : R[n,n], B : R[n,n], C : R[n,n]):
+    def matmul(n: size, A: R[n, n], B: R[n, n], C: R[n, n]):
         for i in seq(0, n):
             for j in seq(0, n):
                 for k in seq(0, n):
-                    C[i,j] += A[i,k] * B[k,j]
+                    C[i, j] += A[i, k] * B[k, j]
 
     matmul = stage_mem(matmul, 'for k in _:_', 'C[i, j]', 'res')
     assert str(simplify(matmul)) == golden
+
 
 def test_fail_stage_mem():
     # This test fails to stage the buffer B
     # because it's not just being read in a single way
     # therefore the bounds check will fail
     @proc
-    def sqmat(n : size, A : R[n,n], B : R[n,n]):
+    def sqmat(n: size, A: R[n, n], B: R[n, n]):
         assert n % 4 == 0
-        for i in seq(0,n/4):
-            for j in seq(0,n/4):
-                for k in seq(0,n/4):
-                    for ii in seq(0,4):
-                        for jj in seq(0,4):
-                            for kk in seq(0,4):
-                                A[4*i+ii,4*j+jj] += ( B[4*i+ii,4*k+kk] *
-                                                      B[4*k+kk,4*j+jj] )
+        for i in seq(0, n / 4):
+            for j in seq(0, n / 4):
+                for k in seq(0, n / 4):
+                    for ii in seq(0, 4):
+                        for jj in seq(0, 4):
+                            for kk in seq(0, 4):
+                                A[4 * i + ii, 4 * j + jj] += (
+                                            B[4 * i + ii, 4 * k + kk] *
+                                            B[4 * k + kk, 4 * j + jj])
 
     with pytest.raises(SchedulingError,
                        match='accessed out-of-bounds'):
         sqmat = stage_mem(sqmat, 'for ii in _: _',
-                                 'B[4*i:4*i+4, 4*k:4*k+4]', 'Btile')
+                          'B[4*i:4*i+4, 4*k:4*k+4]', 'Btile')
+
 
 def test_stage_mem_twice(golden):
     # This test now finds a way to stage the buffer B twice
     @proc
-    def sqmat(n : size, A : R[n,n], B : R[n,n]):
+    def sqmat(n: size, A: R[n, n], B: R[n, n]):
         assert n % 4 == 0
-        for i in seq(0,n/4):
-            for j in seq(0,n/4):
-                for k in seq(0,n/4):
-                    for ii in seq(0,4):
-                        for jj in seq(0,4):
-                            for kk in seq(0,4):
-                                A[4*i+ii,4*j+jj] += ( B[4*i+ii,4*k+kk] *
-                                                      B[4*k+kk,4*j+jj] )
+        for i in seq(0, n / 4):
+            for j in seq(0, n / 4):
+                for k in seq(0, n / 4):
+                    for ii in seq(0, 4):
+                        for jj in seq(0, 4):
+                            for kk in seq(0, 4):
+                                A[4 * i + ii, 4 * j + jj] += (
+                                            B[4 * i + ii, 4 * k + kk] *
+                                            B[4 * k + kk, 4 * j + jj])
 
     sqmat = bind_expr(sqmat, 'B[4*i+ii,4*k+kk]', 'B1')
     sqmat = expand_dim(sqmat, 'B1 : _', '4', 'kk')
@@ -1202,7 +1232,7 @@ def test_stage_mem_twice(golden):
     sqmat = autolift_alloc(sqmat, 'B1 : _', n_lifts=3)
     sqmat = autofission(sqmat, sqmat.find('B1[_] = _').after(), n_lifts=3)
     sqmat = stage_mem(sqmat, 'for ii in _: _ #1',
-                             'B[4*k:4*k+4, 4*j:4*j+4]', 'B2')
+                      'B[4*k:4*k+4, 4*j:4*j+4]', 'B2')
     assert str(simplify(sqmat)) == golden
 
 
@@ -1210,24 +1240,26 @@ def test_stage_mem_accum(golden):
     # This test stages a buffer being accumulated in
     # on a per-tile basis
     @proc
-    def sqmat(n : size, A : R[n,n], B : R[n,n]):
+    def sqmat(n: size, A: R[n, n], B: R[n, n]):
         assert n % 4 == 0
-        for i in seq(0,n/4):
-            for j in seq(0,n/4):
-                for k in seq(0,n/4):
-                    for ii in seq(0,4):
-                        for jj in seq(0,4):
-                            for kk in seq(0,4):
-                                A[4*i+ii,4*j+jj] += ( B[4*i+ii,4*k+kk] *
-                                                      B[4*k+kk,4*j+jj] )
+        for i in seq(0, n / 4):
+            for j in seq(0, n / 4):
+                for k in seq(0, n / 4):
+                    for ii in seq(0, 4):
+                        for jj in seq(0, 4):
+                            for kk in seq(0, 4):
+                                A[4 * i + ii, 4 * j + jj] += (
+                                            B[4 * i + ii, 4 * k + kk] *
+                                            B[4 * k + kk, 4 * j + jj])
 
     sqmat = stage_mem(sqmat, 'for k in _: _', 'A[4*i:4*i+4, 4*j:4*j+4]',
-                             'Atile',  accum=True)
+                      'Atile', accum=True)
     assert str(simplify(sqmat)) == golden
+
 
 def test_stage_mem_accum2(golden):
     @proc
-    def accum(out : R[4, 16, 16], w : R[16], im : R[16]):
+    def accum(out: R[4, 16, 16], w: R[16], im: R[16]):
         for k in seq(0, 4):
             for i in seq(0, 16):
                 for j in seq(0, 16):


### PR DESCRIPTION
Very often, entire trees would be rewritten by the default rules of LoopIR_Rewrite. This causes increased memory pressure and is generally wasteful. This PR fixes that... and all the scheduling directives reachable from our tests,