### PR TITLE
Use Ubuntu 20.04 for testing Gemmini

### DIFF
--- a/.github/workflows/gemmini.yml
+++ b/.github/workflows/gemmini.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   gemmini:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     container:
       image: ghcr.io/exo-lang/gemmini:latest


### PR DESCRIPTION
The chipyard toolchain docker images are built on Ubuntu 20.04 LTS, but the `ubuntu-latest` tag just moved to 22.04. So we need to pin this workflow to 20.04 LTS until we can rebuild the image on 22.04.