### PR TITLE
Mark slow tests as such in PyTest.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ filterwarnings = [
 ]
 norecursedirs = ['dependencies']
 pythonpath = "src/"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.black]
 exclude = '(demo_stage\.py|dependencies/.*|build/.*)'

--- a/tests/pldi22/test_gemmini_conv_ae.py
+++ b/tests/pldi22/test_gemmini_conv_ae.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from exo.platforms.gemmini import *
 
 
@@ -63,6 +65,7 @@ def conv_algorithm():
 
 # Conv test for the artifact evaluation. The same algorithm and schedule
 # was used for Table 2 (first row) and Table 3 (code size)
+@pytest.mark.slow
 def test_conv_ae(golden):
     batch_size = 4
     out_channel = 64

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 import exo
 import exo.main
 
@@ -36,11 +38,13 @@ def test_neon_sgemm(golden):
     assert _test_app(module_file) == golden
 
 
+@pytest.mark.slow
 def test_gemmini_matmul(golden):
     module_file = REPO_ROOT / "apps" / "gemmini" / "src" / "exo" / "matmul.py"
     assert _test_app(module_file) == golden
 
 
+@pytest.mark.slow
 def test_gemmini_conv(golden):
     module_file = REPO_ROOT / "apps" / "gemmini" / "src" / "exo" / "conv.py"
     assert _test_app(module_file) == golden


### PR DESCRIPTION
This is just a developer convenience.

Run pytest with `pytest -m "not slow"` to run only the fast tests. With this, the whole test suite takes about a minute on my laptop. Works well with `-n $(nproc)` for parallelism. Does NOT work well with `--update-golden` because all golden outputs should typically be updated at once.