### PR TITLE
CMake package fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Take a look at `exo/examples` for scheduling examples.
 | `.set_window(name, is_window)`   | If `is_window` is True, it sets the buffer `name` to window type, instead of a tensor type.                                                                                                  |
 | `.set_memory(name, mem_type)`    | Sets a buffer `name`'s memory type to `mem_type`.                                                                                                                                            |
 
-
 # Developing Exo
 
 If you plan to work on the compiler directly, you should run the following
@@ -139,7 +138,6 @@ In this repository, folders are structured as follows:
    ignored.
 5. `tests/` contains the Exo test suite.
 
-
 # Build Exo from source
 
 We make active use of newer Python 3.x features, so please use the same version
@@ -153,7 +151,7 @@ $ git clone git@github.com:exo-lang/exo.git
 $ cd exo/
 $ git submodule update --init --recursive
 $ python -m venv ~/.venv/exo
-$ . ~/.venv/exo
+$ source ~/.venv/exo/bin/activate
 (exo) $ python -m pip install -U pip setuptools wheel
 (exo) $ python -m pip install -r requirements.txt
 (exo) $ python -m build
@@ -216,7 +214,8 @@ Then, if you want to see annotated source files, open `./htmlcov/index.html`.
 
 # Publication
 
-The first paper on Exo was published at PLDI '22. You can download the paper [from ACM Digital Library](https://dl.acm.org/doi/abs/10.1145/3519939.3523446).
+The first paper on Exo was published at PLDI '22. You can download the
+paper [from ACM Digital Library](https://dl.acm.org/doi/abs/10.1145/3519939.3523446).
 If you use Exo, please consider citing.
 
 ```

--- a/apps/aarch64/sgemm/CMakeLists.txt
+++ b/apps/aarch64/sgemm/CMakeLists.txt
@@ -15,9 +15,7 @@ if (EXISTS "$ENV{PYENV_ROOT}")
       CACHE PATH "Path to Python3 root directory")
 endif ()
 
-find_package(Python3 REQUIRED)
-message("STATUS" "${Python3_ROOT_DIR}")
-find_package(Exo REQUIRED HINTS "${Python3_SITELIB}")
+find_package(Exo REQUIRED)
 
 # ---------------------------------------------------------------------------- #
 # Exo libraries

--- a/apps/gemmini/CMakeLists.txt
+++ b/apps/gemmini/CMakeLists.txt
@@ -29,8 +29,7 @@ endif ()
 # Dependencies
 
 ## Exo
-find_package(Python3 REQUIRED)
-find_package(Exo REQUIRED HINTS "${Python3_SITELIB}")
+find_package(Exo REQUIRED)
 
 ## gemmini-rocc-tests
 include(FetchContent)

--- a/apps/x86/CMakeLists.txt
+++ b/apps/x86/CMakeLists.txt
@@ -13,8 +13,7 @@ endif ()
 # Dependencies
 
 ## Exo
-find_package(Python3 REQUIRED)
-find_package(Exo REQUIRED HINTS "${Python3_SITELIB}")
+find_package(Exo REQUIRED)
 
 ## oneAPI MKL
 set(MKL_ARCH "intel64"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,11 +48,14 @@ install_requires =
 where = src
 
 [options.package_data]
-exo =
-    cmake/*
 exo.libs =
     *.c
+    *.h
 
 [options.entry_points]
 console_scripts =
     exocc = exo.main:main
+
+[options.data_files]
+share/exo/cmake =
+    src/exo/cmake/*.cmake

--- a/src/exo/cmake/ExoConfig.cmake
+++ b/src/exo/cmake/ExoConfig.cmake
@@ -5,42 +5,25 @@ if (NOT CMAKE_FIND_PACKAGE_NAME STREQUAL "Exo")
 endif ()
 
 include(CMakeFindDependencyMacro)
-find_dependency(Python3)
+find_dependency(Python 3.9)
 
-find_program(Exo_CC_EXECUTABLE exocc
-             HINTS "${Python3_ROOT_DIR}/bin")
-mark_as_advanced(Exo_CC_EXECUTABLE)
-
-if (NOT Exo_CC_EXECUTABLE)
-    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
-        "Could not find exocc!")
-    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
-    return()
-endif ()
-
-execute_process(
-  COMMAND "${Exo_CC_EXECUTABLE}" --version
-  OUTPUT_VARIABLE Exo_version_output
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  COMMAND_ERROR_IS_FATAL ANY
+find_program(
+  Exo_EXECUTABLE exocc
+  HINTS
+  "${Python_ROOT_DIR}/bin"
+  "${Python_ROOT}/bin"
 )
+mark_as_advanced(Exo_EXECUTABLE)
 
-if (Exo_version_output MATCHES "version ([0-9]+\\.[0-9]+\\.[0-9]+)")
-  set(Exo_VERSION "${CMAKE_MATCH_1}")
-else ()
-  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
-        "Could not determine version using exocc!")
+if (NOT Exo_EXECUTABLE)
+  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "Could not find exocc!")
   set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
   return()
 endif ()
 
 if (NOT TARGET Exo::compiler)
   add_executable(Exo::compiler IMPORTED)
-  set_target_properties(
-    Exo::compiler
-    PROPERTIES
-      IMPORTED_LOCATION "${Exo_CC_EXECUTABLE}"
-  )
+  set_target_properties(Exo::compiler PROPERTIES IMPORTED_LOCATION "${Exo_EXECUTABLE}")
 endif ()
 
 include("${CMAKE_CURRENT_LIST_DIR}/AddExoLibrary.cmake")

--- a/src/exo/cmake/ExoConfigVersion.cmake
+++ b/src/exo/cmake/ExoConfigVersion.cmake
@@ -11,7 +11,7 @@
 # This is all that Exo should need to change.
 set(CVF_VERSION_MAJOR "0")
 set(CVF_VERSION_MINOR "0")
-set(CVF_VERSION_PATCH "1")
+set(CVF_VERSION_PATCH "2")
 
 set(PACKAGE_VERSION "${CVF_VERSION_MAJOR}.${CVF_VERSION_MINOR}.${CVF_VERSION_PATCH}")
 


### PR DESCRIPTION
This has been a little annoying for a while. But this should simplify CMake build system / project set up for Exo users.

Where previously you had to write:

```cmake
find_package(Python 3.9 REQUIRED)
find_package(Exo REQUIRED HINTS "${Python_SITELIB}")
```

Now the following suffices:

```cmake
find_package(Exo REQUIRED)
```

To-do: 
- [x] ~support for editable installs~ not worth attempting - they're too unpleasant to use
- [x] out-of-venv installs.