### PR TITLE
Replace bind expr with stage mem

### DIFF
--- a/apps/aarch64/sgemm/sgemm.py
+++ b/apps/aarch64/sgemm/sgemm.py
@@ -104,10 +104,7 @@ neon_microkernel = stage_C_microkernel()
 
 def stage_A_B_microkernel(p=neon_microkernel):
     for buf in ("A", "B"):
-        p = bind_expr(p, f"{buf}[_]", f"{buf}_vec")
-        p = expand_dim(p, f"{buf}_vec", 4, "ji", unsafe_disable_checks=True)
-        p = lift_alloc(p, f"{buf}_vec")
-        p = fission(p, p.find(f"{buf}_vec[_] = _").after())
+        p = stage_expr(p, f"{buf}[_]", 4, "ji", f"{buf}_vec")
         p = set_memory(p, f"{buf}_vec", Neon4f)
     #
     p = replace_all(p, neon_vld_4xf32)

--- a/apps/x86/conv/conv.py
+++ b/apps/x86/conv/conv.py
@@ -94,11 +94,8 @@ def do_specialization(p):
     p = repeat(reorder_loops)(p, "oc_u ox_i")
     #
     def stage_input(p, read_expr, name):
-        p = bind_expr(p, read_expr, name)
-        p = expand_dim(p, name, 16, "oc_v")
-        p = lift_alloc(p, name)
+        p = stage_expr(p, read_expr, 16, "oc_v", name)
         p = set_memory(p, name, AVX512)
-        p = fission(p, p.find(f"{name}[_] = _").after())
         return p
 
     p = stage_input(p, "weights[_]", "wt_vec")

--- a/apps/x86/sgemm/sgemm.py
+++ b/apps/x86/sgemm/sgemm.py
@@ -91,11 +91,8 @@ for M in range(1, M_REG_BLK + 1):
         p = autofission(p, p.find("C[_] = _").before(), n_lifts=4)
         # Stage A & B
         def stage_input(p, expr, new_buf):
-            p = bind_expr(p, expr, new_buf)
-            p = expand_dim(p, new_buf, 16, "ji")
-            p = lift_alloc(p, new_buf)
+            p = stage_expr(p, expr, 16, "ji", new_buf)
             p = set_memory(p, new_buf, AVX512)
-            p = fission(p, p.find(f"{new_buf} = _").after())
             return p
 
         p = stage_input(p, "A[_]", "A_vec")
@@ -181,11 +178,10 @@ def make_right_panel_kernel_opt(p=right_panel_kernel):
     p = set_memory(p, "C_reg", AVX512)
     #
     def stage_input(p, expr, new_buf, n_lifts=1):
-        p = bind_expr(p, expr, new_buf)
-        p = expand_dim(p, new_buf, 16, "ji", unsafe_disable_checks=True)
-        p = lift_alloc(p, new_buf, n_lifts=n_lifts)
+        p = stage_expr(
+            p, expr, 16, "ji", new_buf, n_lifts=n_lifts, unsafe_disable_checks=True
+        )
         p = set_memory(p, new_buf, AVX512)
-        p = fission(p, p.find(f"{new_buf} = _").after(), n_lifts=n_lifts)
         return p
 
     p = stage_input(p, "A[_]", "A_reg")

--- a/src/exo/stdlib/scheduling.py
+++ b/src/exo/stdlib/scheduling.py
@@ -251,3 +251,15 @@ def lift_if(proc, cursor, n_lifts=1):
                 proc=proc,
             ) from e
     return proc
+
+
+def stage_expr(
+    proc, expr_cursor, new_dim, iter, new_name, n_lifts=1, unsafe_disable_checks=False
+):
+    proc = bind_expr(proc, expr_cursor, new_name)
+    proc = expand_dim(
+        proc, new_name, new_dim, iter, unsafe_disable_checks=unsafe_disable_checks
+    )
+    proc = lift_alloc(proc, new_name, n_lifts=n_lifts)
+    proc = fission(proc, proc.find(f"{new_name} = _").after(), n_lifts=n_lifts)
+    return proc

--- a/tests/golden/pldi22/test_gemmini_matmul_paper/test_matmul_paper.txt
+++ b/tests/golden/pldi22/test_gemmini_matmul_paper/test_matmul_paper.txt
@@ -3,8 +3,8 @@ def matmul_on_gemmini(A: R[128, 128] @ DRAM, B: R[128, 128] @ DRAM,
     config_st_acc(stride(C, 0))
     config_matmul()
     res: R[8, 8, 16, 16] @ DRAM
-    a: R[8, 8, 16, 16]
-    b: R[8, 8, 16, 16]
+    a: R[8, 8, 16, 16] @ DRAM
+    b: R[8, 8, 16, 16] @ DRAM
     for io in seq(0, 8):
         for jo in seq(0, 8):
             config_ld(stride(C, 0))

--- a/tests/golden/test_im2col/test_im2col.txt
+++ b/tests/golden/test_im2col/test_im2col.txt
@@ -17,6 +17,6 @@ def im2col_conv(K: size, C: size, W: size, R: size, w: R[K, C, R] @ DRAM,
     for k_init in seq(0, K):
         for i_init in seq(0, W):
             res[k_init, i_init] = 0.0
-    y: R[C + 1, R + 1, W + 1]
+    y: R[C + 1, R + 1, W + 1] @ DRAM
     im2col(C, R, W, x, y)
     tiled_matmul(C, K, R, W, res, w, y)

--- a/tests/pldi22/test_gemmini_matmul_paper.py
+++ b/tests/pldi22/test_gemmini_matmul_paper.py
@@ -359,8 +359,8 @@ def test_matmul_paper(golden):
 
     # Stage memories, so that we can use gemmini scratchpad & accumulator
     gemmini = stage_mem(gemmini, "for k in _: _", "C[i, j]", "res")
-    gemmini = bind_expr(gemmini, "A[_]", "a")
-    gemmini = bind_expr(gemmini, "B[_]", "b")
+    gemmini = stage_mem(gemmini, "res += _", "A[i, k]", "a")
+    gemmini = stage_mem(gemmini, "res += _", "B[k, j]", "b")
 
     # Tile dimensions
     gemmini = old_split(gemmini, "i", 16, ["io", "ii"], perfect=True)

--- a/tests/test_im2col.py
+++ b/tests/test_im2col.py
@@ -43,7 +43,7 @@ def test_im2col(golden):
     # Let's start applying scheduling
     im2col_conv = rename(conv1d, "im2col_conv")
     im2col_conv = reorder_loops(im2col_conv, "i r")
-    im2col_conv = bind_expr(im2col_conv, "x[c, i-r]", "y")
+    im2col_conv = stage_mem(im2col_conv, "res[_] += _", "x[c, i-r]", "y")
 
     # next, we can start to lift that allocation
     # up and out of the loop

--- a/tests/test_neon.py
+++ b/tests/test_neon.py
@@ -146,9 +146,7 @@ def simple_math_neon_sched():
 
         p = stage_mem(p, "for ii in _:_ #0", "y[4 * io : 4 * io + 4]", "yVec")
 
-        p = bind_expr(p, "xVec[_] * yVec[_]", "xy")
-        p = autolift_alloc(p, "xy: _", keep_dims=True)
-        p = fission(p, p.find("xy[_] = _").after())
+        p = stage_expr(p, "xVec[_] * yVec[_]", 4, "ii", "xy")
 
         p = set_memory(p, "xVec", Neon4f)
         p = set_memory(p, "yVec", Neon4f)

--- a/tests/test_x86.py
+++ b/tests/test_x86.py
@@ -112,10 +112,8 @@ def simple_math_avx2_sched():
 
         p = replace_all(p, mm256_loadu_ps)
 
-        p = bind_expr(p, "xVec[_] * yVec[_]", "xy")
-        p = autolift_alloc(p, "xy: _", keep_dims=True)
+        p = stage_expr(p, "xVec[_] * yVec[_]", 8, "ii", "xy")
         p = set_memory(p, "xy", AVX2)
-        p = old_fission_after(p, "xy[_] = _")
 
         p = replace_all(p, mm256_mul_ps)
         p = simplify(p)
@@ -195,11 +193,8 @@ def avx2_sgemm_6x16(sgemm_6x16):
     avx2_sgemm_6x16 = avx
 
     def sched_avx2_sgemm_6x16(p=avx2_sgemm_6x16):
-        p = bind_expr(p, "A[i, k]", "a_vec")
+        p = stage_expr(p, "A[i, k]", "8", "ji", "a_vec")
         p = set_memory(p, "a_vec", AVX2)
-        p = expand_dim(p, "a_vec:_", "8", "ji")
-        p = autolift_alloc(p, "a_vec:_")
-        p = old_fission_after(p, "a_vec[_] = _")
         #
         p = stage_mem(p, "for ji in _:_ #2", "B[k, 8 * jo:8 + 8 * jo]", "b_vec")
         p = set_memory(p, "b_vec", AVX2)


### PR DESCRIPTION
An attempt at addressing #160 

It removes all usages of `bind_expr` and replaces it with `stage_mem` or a new stdlib function `stage_expr`. Only remaining usages are in examples/demo.

`bind_expr` is used throughout the codebase to perform manual staging of expressions. Many of those staging patterns can be refactored to completely use `stage_mem`. However, there are a few situations where that's not possible.
1. Staging to do a broadcast (for example when you want to stage `A` in matrix multiply, see test_x86.py::avx2_sgemm_6x16).
3. Staging a binop expressions (see test_x86.py::simple_math_avx2_sched)
4. Staging the temporary buffer into a buffer with higher dimensions than the original buffer (see test_im2col.py::test_im2col)

1 and 2 code patterns could be refactored into one function which I added into stdlib called `stage_expr`. However, the function ended up being too parameterized and has a problem where it could accept multiple expression cursors in the first step of `bind_expr`, but the function is really assuming one expression cursor. 

For 3, I simply replaced the call to `bind_expr` with a call to `stage_mem` but left the remainder of the staging pattern.

It seems that it is not possible to completely deprecate `bind_expr` because it is necessary for usages of binop expressions staging as in 2. Moreover, it seems that the implementation of `stage_expr` is not a good idea at least in it is the current way it is written. Finally, for 3 it seems more natural to use `bind_expr` instead of `stage_mem` since in that case, `stage_mem` is behaving exactly like `bind_expr` by removing the store subsequent to the block. For cases like 1, we could try to remove the staging pattern with `stage_mem` and try to use other scheduling primitives to achieve broadcasting, but that seems unnecessary if we have to keep `bind_expr` anyways.

In short, it might be best to keep `bind_expr`, and only replace its usage with `stage_mem` where the entire staging pattern could be removed.