### PR TITLE
Add Formatted Expressions

### DIFF
--- a/src/exo/API_cursors.py
+++ b/src/exo/API_cursors.py
@@ -492,7 +492,7 @@ class ForSeqCursor(StmtCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node().iter
 
     def hi(self) -> ExprCursor:
         return new_Cursor(self._impl._child_node("hi"))

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -614,7 +614,7 @@ class NewExprA(ArgumentProcessor):
         return ctxt_stmt
 
     def __call__(self, expr_str, all_args):
-        holes = []
+        expr_holes = None
         if isinstance(expr_str, int):
             return LoopIR.Const(expr_str, T.int, null_srcinfo())
         elif isinstance(expr_str, float):
@@ -622,7 +622,7 @@ class NewExprA(ArgumentProcessor):
         elif isinstance(expr_str, bool):
             return LoopIR.Const(expr_str, T.bool, null_srcinfo())
         elif isinstance(expr_str, FormattedExpr):
-            holes = [i._impl._node() for i in expr_str._holes]
+            expr_holes = [i._impl._node() for i in expr_str._holes]
             expr_str = expr_str._str
         elif not isinstance(expr_str, str):
             self.err("expected a string")
@@ -630,7 +630,9 @@ class NewExprA(ArgumentProcessor):
         proc = all_args["proc"]
         ctxt_stmt = self._get_ctxt_stmt(all_args)
 
-        expr = parse_fragment(proc._loopir_proc, expr_str, ctxt_stmt, expr_holes=holes)
+        expr = parse_fragment(
+            proc._loopir_proc, expr_str, ctxt_stmt, expr_holes=expr_holes
+        )
         return expr
 
 

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -587,7 +587,7 @@ class CallCursorA(StmtCursorA):
 
 
 @dataclass
-class FormattedExpr:
+class FormattedExprStr:
     """
     Allows the user to provide a string with holes in it along with a list of
     `CursorExprs` to fill the holes. The object is designed as a wrapper to allow
@@ -611,7 +611,7 @@ class FormattedExpr:
 
     def _get(self):
         if self._expr_str is None:
-            raise ValueError("Cannot reuse FormattedExpr object")
+            raise ValueError("Cannot reuse FormattedExprStr object")
 
         expr_str, expr_holes = self._expr_str, self._expr_holes
         self._expr_str = None
@@ -648,7 +648,7 @@ class NewExprA(ArgumentProcessor):
             return LoopIR.Const(expr_str, T.R, null_srcinfo())
         elif isinstance(expr_str, bool):
             return LoopIR.Const(expr_str, T.bool, null_srcinfo())
-        elif isinstance(expr_str, FormattedExpr):
+        elif isinstance(expr_str, FormattedExprStr):
             expr_str, expr_holes = expr_str._get()
         elif not isinstance(expr_str, str):
             self.err("expected a string")

--- a/src/exo/parse_fragment.py
+++ b/src/exo/parse_fragment.py
@@ -213,7 +213,7 @@ class ParseFragment:
                 raise ParseFragmentError(
                     f"{pat.name} not found in the " + "current environment"
                 )
-            idx = [self.find_sym(i) for i in pat.idx]
+            idx = [self.parse_e(i) for i in pat.idx]
             return LoopIR.Read(nm, idx, self.env[nm], self.srcinfo)
         elif isinstance(pat, PAST.BinOp):
             lhs = self.parse_e(pat.lhs)
@@ -287,9 +287,8 @@ class ParseFragment:
 
         if isinstance(loopIR_expr, LoopIR.Read):
             check_sym_consistency(loopIR_expr.name)
-            for idx in loopIR_expr.idx:
-                check_sym_consistency(idx)
-            return loopIR_expr.update(srcinfo=self.srcinfo)
+            idx = [self.rebuild_ast(i) for i in loopIR_expr.idx]
+            return loopIR_expr.update(idx=idx, srcinfo=self.srcinfo)
         elif isinstance(loopIR_expr, LoopIR.Const):
             return loopIR_expr.update(srcinfo=self.srcinfo)
         elif isinstance(loopIR_expr, loopIR.USub):

--- a/src/exo/parse_fragment.py
+++ b/src/exo/parse_fragment.py
@@ -264,10 +264,6 @@ class ParseFragment:
                     "String contains more holes than expressions provided"
                 )
             subtree = self.expr_holes[0]
-            if not isinstance(subtree, LoopIR.expr):
-                raise ParseFragmentError(
-                    "Cannot fill hole in an expression fragment using a non-expression"
-                )
             self.expr_holes = self.expr_holes[1:]
             return subtree
         else:

--- a/src/exo/parse_fragment.py
+++ b/src/exo/parse_fragment.py
@@ -20,7 +20,7 @@ class ParseFragmentError(Exception):
 
 
 def parse_fragment(
-    proc, fragment, ctx_stmt, call_depth=0, configs=[], scope="before", expr_holes=[]
+    proc, fragment, ctx_stmt, call_depth=0, configs=[], scope="before", expr_holes=None
 ):
     # get source location where this is getting called from
     caller = inspect.getframeinfo(inspect.stack()[call_depth + 1][0])
@@ -257,8 +257,12 @@ class ParseFragment:
             typ = cfg.lookup(pat.field)[1]
             return LoopIR.ReadConfig(cfg, pat.field, typ, self.srcinfo)
         elif isinstance(pat, PAST.E_Hole):
+            if self.expr_holes == None:
+                raise ParseFragmentError("String cannot contain holes")
             if len(self.expr_holes) == 0:
-                raise ParseFragmentError("Too many holes in expression")
+                raise ParseFragmentError(
+                    "String contains more holes than expressions provided"
+                )
             subtree = self.expr_holes[0]
             if not isinstance(subtree, LoopIR.expr):
                 raise ParseFragmentError(

--- a/src/exo/parse_fragment.py
+++ b/src/exo/parse_fragment.py
@@ -260,6 +260,10 @@ class ParseFragment:
             if len(self.expr_holes) == 0:
                 raise ParseFragmentError("Too many holes in expression")
             subtree = self.expr_holes[0]
+            if not isinstance(subtree, LoopIR.expr):
+                raise ParseFragmentError(
+                    "Cannot fill hole in an expression fragment using a non-expression"
+                )
             self.expr_holes = self.expr_holes[1:]
             return subtree
         else:

--- a/src/exo/prelude.py
+++ b/src/exo/prelude.py
@@ -41,6 +41,14 @@ class Sym:
         assert isinstance(rhs, Sym)
         return (self._nm, self._id) < (rhs._nm, rhs._id)
 
+    def __eq__(self, rhs):
+        if not isinstance(rhs, Sym):
+            return False
+        return self._nm == rhs._nm and self._id == rhs._id
+
+    def __ne__(self, rhs):
+        return not (self == rhs)
+
     def name(self):
         return self._nm
 

--- a/src/exo/stdlib/scheduling.py
+++ b/src/exo/stdlib/scheduling.py
@@ -11,6 +11,7 @@ from ..API import (
 
 from ..API_scheduling import (
     is_atomic_scheduling_op,
+    FormattedExpr,
     # basic operations
     simplify,
     rename,

--- a/src/exo/stdlib/scheduling.py
+++ b/src/exo/stdlib/scheduling.py
@@ -11,7 +11,7 @@ from ..API import (
 
 from ..API_scheduling import (
     is_atomic_scheduling_op,
-    FormattedExpr,
+    FormattedExprStr,
     # basic operations
     simplify,
     rename,

--- a/tests/golden/test_schedules/test_formatted_expr_1.txt
+++ b/tests/golden/test_schedules/test_formatted_expr_1.txt
@@ -1,0 +1,5 @@
+def bar(n: size, arr: R[n] @ DRAM):
+    for i in seq(0, n):
+        tmp: R[n + 1] @ DRAM
+        tmp[i] = 1.0
+        arr[i] = tmp[i]

--- a/tests/golden/test_schedules/test_formatted_expr_2.txt
+++ b/tests/golden/test_schedules/test_formatted_expr_2.txt
@@ -1,0 +1,6 @@
+def bar(n: size, m: size, arr: R[n, m] @ DRAM):
+    for i in seq(0, n):
+        for j in seq(0, m):
+            tmp: R[(n + 1) * (1 + m)] @ DRAM
+            tmp[i * m + j] = 1.0
+            arr[i, j] = tmp[i * m + j]

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1544,15 +1544,22 @@ def test_formatted_expr_3(golden):
             tmp = 1.0
             arr[i] = tmp
 
-    with pytest.raises(ParseFragmentError, match="Too many holes in expression"):
+    with pytest.raises(
+        ParseFragmentError, match="String contains more holes than expressions provided"
+    ):
         expand_dim(bar, "tmp : _", FormattedExpr("1 + _", []), "i")  # should be error
 
-    with pytest.raises(ParseFragmentError, match="Too many holes in expression"):
+    with pytest.raises(
+        ParseFragmentError, match="String contains more holes than expressions provided"
+    ):
         alloc_stmt = bar.find("tmp : _")
         seq_for_hi = alloc_stmt.parent().hi()
         expand_dim(
             bar, "tmp : _", FormattedExpr("1 + _ + _", [seq_for_hi]), "i"
         )  # should be error
+
+    with pytest.raises(ParseFragmentError, match="String cannot contain holes"):
+        expand_dim(bar, "tmp : _", "1 + _", "i")  # should be error
 
     with pytest.raises(
         ParseFragmentError,

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1497,4 +1497,40 @@ def test_new_expr_multi_vars(golden):
         i = 1.0
 
     bar = expand_dim(bar, "tmp : _", "n", "i")
+
+
+def test_formatted_expr_1(golden):
+    @proc
+    def bar(n: size, arr: R[n] @ DRAM):
+        for i in seq(0, n):
+            tmp: R
+            tmp = 1.0
+            arr[i] = tmp
+
+    alloc_stmt = bar.find("tmp : _")
+    seq_for_hi = alloc_stmt.parent().hi()
+    seq_for_iter = alloc_stmt.parent().name()
+    bar = expand_dim(
+        bar, "tmp : _", FormattedExpr("_ + 1", [seq_for_hi]), str(seq_for_iter)
+    )
+    assert str(bar) == golden
+
+
+def test_formatted_expr_2(golden):
+    @proc
+    def bar(n: size, m: size, arr: R[n, m] @ DRAM):
+        for i in seq(0, n):
+            for j in seq(0, m):
+                tmp: R
+                tmp = 1.0
+                arr[i, j] = tmp
+
+    alloc_stmt = bar.find("tmp : _")
+    seq_i = alloc_stmt.parent()
+    seq_o = seq_i.parent()
+    new_dim = FormattedExpr("(_ + 1) * (1 + _)", [seq_o.hi(), seq_i.hi()])
+    indexing_expr = FormattedExpr(f"{seq_o.name()} * _ + {seq_i.name()}", [seq_i.hi()])
+
+    bar = expand_dim(bar, "tmp : _", new_dim, indexing_expr)
+
     assert str(bar) == golden

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1511,7 +1511,7 @@ def test_formatted_expr_1(golden):
     seq_for_hi = alloc_stmt.parent().hi()
     seq_for_iter = alloc_stmt.parent().name()
     bar = expand_dim(
-        bar, "tmp : _", FormattedExprStr("_ + 1", [seq_for_hi]), str(seq_for_iter)
+        bar, "tmp : _", FormattedExprStr("_ + 1", seq_for_hi), str(seq_for_iter)
     )
     assert str(bar) == golden
 
@@ -1528,10 +1528,8 @@ def test_formatted_expr_2(golden):
     alloc_stmt = bar.find("tmp : _")
     seq_i = alloc_stmt.parent()
     seq_o = seq_i.parent()
-    new_dim = FormattedExprStr("(_ + 1) * (1 + _)", [seq_o.hi(), seq_i.hi()])
-    indexing_expr = FormattedExprStr(
-        f"{seq_o.name()} * _ + {seq_i.name()}", [seq_i.hi()]
-    )
+    new_dim = FormattedExprStr("(_ + 1) * (1 + _)", seq_o.hi(), seq_i.hi())
+    indexing_expr = FormattedExprStr(f"{seq_o.name()} * _ + {seq_i.name()}", seq_i.hi())
 
     bar = expand_dim(bar, "tmp : _", new_dim, indexing_expr)
 
@@ -1549,9 +1547,7 @@ def test_formatted_expr_errors_1():
     with pytest.raises(
         ParseFragmentError, match="String contains more holes than expressions provided"
     ):
-        expand_dim(
-            bar, "tmp : _", FormattedExprStr("1 + _", []), "i"
-        )  # should be error
+        expand_dim(bar, "tmp : _", FormattedExprStr("1 + _"), "i")  # should be error
 
     with pytest.raises(
         ParseFragmentError, match="String contains more holes than expressions provided"
@@ -1559,7 +1555,7 @@ def test_formatted_expr_errors_1():
         alloc_stmt = bar.find("tmp : _")
         seq_for_hi = alloc_stmt.parent().hi()
         expand_dim(
-            bar, "tmp : _", FormattedExprStr("1 + _ + _", [seq_for_hi]), "i"
+            bar, "tmp : _", FormattedExprStr("1 + _ + _", seq_for_hi), "i"
         )  # should be error
 
     with pytest.raises(ParseFragmentError, match="String cannot contain holes"):
@@ -1571,13 +1567,13 @@ def test_formatted_expr_errors_1():
     ):
         alloc_stmt = bar.find("tmp : _")
         expand_dim(
-            bar, "tmp : _", FormattedExprStr("1 + _", [alloc_stmt]), "i"
+            bar, "tmp : _", FormattedExprStr("1 + _", alloc_stmt), "i"
         )  # should be error
 
     with pytest.raises(ValueError, match="Cannot reuse FormattedExprStr object"):
         alloc_stmt = bar.find("tmp : _")
         seq_for_hi = alloc_stmt.parent().hi()
-        formatted_expr = FormattedExprStr("1 + _", [seq_for_hi])
+        formatted_expr = FormattedExprStr("1 + _", seq_for_hi)
         new_bar = expand_dim(bar, "tmp : _", formatted_expr, "i")
         new_bar = expand_dim(new_bar, "tmp : _", formatted_expr, "i")  # should be error
 
@@ -1604,5 +1600,5 @@ def test_formatted_expr_errors_2():
         seq_for_hi = alloc_stmt.parent().hi()
         seq_for_iter = alloc_stmt.parent().name()
         expand_dim(
-            bar, "tmp : _", "n", FormattedExprStr("_", [i_type_R_read_cursor])
+            bar, "tmp : _", "n", FormattedExprStr("_", i_type_R_read_cursor)
         )  # should be error

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1590,9 +1590,7 @@ def test_formatted_expr_errors_2():
         j: R
         j = i
 
-    with pytest.raises(
-        ParseFragmentError, match="has a different type in current environment"
-    ):
+    with pytest.raises(ParseFragmentError, match="not found in current environment"):
         assign_stmt = bar.find("j = i")
         i_type_R_read_cursor = assign_stmt.rhs()
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1562,10 +1562,17 @@ def test_formatted_expr_3(golden):
         expand_dim(bar, "tmp : _", "1 + _", "i")  # should be error
 
     with pytest.raises(
-        ParseFragmentError,
-        match="Cannot fill hole in an expression fragment using a non-expression",
+        TypeError,
+        match="Cursor provided to fill a hole must be a ExprCursor",
     ):
         alloc_stmt = bar.find("tmp : _")
         expand_dim(
             bar, "tmp : _", FormattedExpr("1 + _", [alloc_stmt]), "i"
         )  # should be error
+
+    with pytest.raises(ValueError, match="Cannot reuse FormattedExpr object"):
+        alloc_stmt = bar.find("tmp : _")
+        seq_for_hi = alloc_stmt.parent().hi()
+        formatted_expr = FormattedExpr("1 + _", [seq_for_hi])
+        new_bar = expand_dim(bar, "tmp : _", formatted_expr, "i")  # should be error
+        new_bar = expand_dim(new_bar, "tmp : _", formatted_expr, "i")  # should be error

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1570,13 +1570,6 @@ def test_formatted_expr_errors_1():
             bar, "tmp : _", FormattedExprStr("1 + _", alloc_stmt), "i"
         )  # should be error
 
-    with pytest.raises(ValueError, match="Cannot reuse FormattedExprStr object"):
-        alloc_stmt = bar.find("tmp : _")
-        seq_for_hi = alloc_stmt.parent().hi()
-        formatted_expr = FormattedExprStr("1 + _", seq_for_hi)
-        new_bar = expand_dim(bar, "tmp : _", formatted_expr, "i")
-        new_bar = expand_dim(new_bar, "tmp : _", formatted_expr, "i")  # should be error
-
 
 def test_formatted_expr_errors_2():
     @proc

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1511,7 +1511,7 @@ def test_formatted_expr_1(golden):
     seq_for_hi = alloc_stmt.parent().hi()
     seq_for_iter = alloc_stmt.parent().name()
     bar = expand_dim(
-        bar, "tmp : _", FormattedExpr("_ + 1", [seq_for_hi]), str(seq_for_iter)
+        bar, "tmp : _", FormattedExprStr("_ + 1", [seq_for_hi]), str(seq_for_iter)
     )
     assert str(bar) == golden
 
@@ -1528,8 +1528,10 @@ def test_formatted_expr_2(golden):
     alloc_stmt = bar.find("tmp : _")
     seq_i = alloc_stmt.parent()
     seq_o = seq_i.parent()
-    new_dim = FormattedExpr("(_ + 1) * (1 + _)", [seq_o.hi(), seq_i.hi()])
-    indexing_expr = FormattedExpr(f"{seq_o.name()} * _ + {seq_i.name()}", [seq_i.hi()])
+    new_dim = FormattedExprStr("(_ + 1) * (1 + _)", [seq_o.hi(), seq_i.hi()])
+    indexing_expr = FormattedExprStr(
+        f"{seq_o.name()} * _ + {seq_i.name()}", [seq_i.hi()]
+    )
 
     bar = expand_dim(bar, "tmp : _", new_dim, indexing_expr)
 
@@ -1547,7 +1549,9 @@ def test_formatted_expr_3(golden):
     with pytest.raises(
         ParseFragmentError, match="String contains more holes than expressions provided"
     ):
-        expand_dim(bar, "tmp : _", FormattedExpr("1 + _", []), "i")  # should be error
+        expand_dim(
+            bar, "tmp : _", FormattedExprStr("1 + _", []), "i"
+        )  # should be error
 
     with pytest.raises(
         ParseFragmentError, match="String contains more holes than expressions provided"
@@ -1555,7 +1559,7 @@ def test_formatted_expr_3(golden):
         alloc_stmt = bar.find("tmp : _")
         seq_for_hi = alloc_stmt.parent().hi()
         expand_dim(
-            bar, "tmp : _", FormattedExpr("1 + _ + _", [seq_for_hi]), "i"
+            bar, "tmp : _", FormattedExprStr("1 + _ + _", [seq_for_hi]), "i"
         )  # should be error
 
     with pytest.raises(ParseFragmentError, match="String cannot contain holes"):
@@ -1567,12 +1571,12 @@ def test_formatted_expr_3(golden):
     ):
         alloc_stmt = bar.find("tmp : _")
         expand_dim(
-            bar, "tmp : _", FormattedExpr("1 + _", [alloc_stmt]), "i"
+            bar, "tmp : _", FormattedExprStr("1 + _", [alloc_stmt]), "i"
         )  # should be error
 
-    with pytest.raises(ValueError, match="Cannot reuse FormattedExpr object"):
+    with pytest.raises(ValueError, match="Cannot reuse FormattedExprStr object"):
         alloc_stmt = bar.find("tmp : _")
         seq_for_hi = alloc_stmt.parent().hi()
-        formatted_expr = FormattedExpr("1 + _", [seq_for_hi])
+        formatted_expr = FormattedExprStr("1 + _", [seq_for_hi])
         new_bar = expand_dim(bar, "tmp : _", formatted_expr, "i")  # should be error
         new_bar = expand_dim(new_bar, "tmp : _", formatted_expr, "i")  # should be error


### PR DESCRIPTION
Add support for allowing users to supply Formatted Expressions. Users can now supply expressions with holes in them along with a list of ExprCursors to use to fill the holes.