### PR TITLE
Fix bug of capturing stmt env in BuildEnv

### DIFF
--- a/src/exo/parse_fragment.py
+++ b/src/exo/parse_fragment.py
@@ -52,6 +52,7 @@ class BuildEnv(LoopIR_Do):
         self.result = None
         self.trg = stmt
         self.proc = proc
+        self.halt = False
 
         for a in self.proc.args:
             self.env[a.name] = a.type
@@ -72,7 +73,10 @@ class BuildEnv(LoopIR_Do):
 
     def do_s(self, s):
         if s == self.trg:
-            self.result = self.env.copy()
+            self.result = self.env
+            self.halt = True
+        if self.halt:
+            return
 
         styp = type(s)
         if styp is LoopIR.Assign or styp is LoopIR.Reduce:

--- a/tests/golden/test_schedules/test_new_expr_multi_vars.txt
+++ b/tests/golden/test_schedules/test_new_expr_multi_vars.txt
@@ -1,0 +1,7 @@
+def bar(n: size, arr: R[n] @ DRAM):
+    for i in seq(0, n):
+        tmp: R[n] @ DRAM
+        tmp[i] = 1.0
+        arr[i] = tmp[i]
+    i: R @ DRAM
+    i = 1.0

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1484,3 +1484,17 @@ def test_stage_mem_accum2(golden):
     accum = stage_mem(accum, "for i in _:_", "out[k, 0:16, 0:16]", "o")
 
     assert str(simplify(accum)) == golden
+
+
+def test_new_expr_multi_vars(golden):
+    @proc
+    def bar(n: size, arr: R[n] @ DRAM):
+        for i in seq(0, n):
+            tmp: R @ DRAM
+            tmp = 1.0
+            arr[i] = tmp
+        i: R @ DRAM
+        i = 1.0
+
+    bar = expand_dim(bar, "tmp : _", "n", "i")
+    assert str(bar) == golden


### PR DESCRIPTION
The visitor was freezing the environment by copying the ChainMap which only copies the first map and keeps refs for the remaining ones. Changed it to always halt after hitting the required statement.

Fixes #305 