### PR TITLE
Make pattern_match always return cursors.

### DIFF
--- a/src/exo/platforms/gemmini.py
+++ b/src/exo/platforms/gemmini.py
@@ -310,7 +310,7 @@ class CanReorder(QAST_Do):
 
 def lift_config(conv, string, nth=0):
     stmt = conv.get_ast(string)
-    stmt = stmt[nth][0]  # Get the match
+    stmt = stmt[nth]  # Get the match
 
     while True:
         proc = conv.get_ast()

--- a/tests/golden/test_reflection/test_show_effect.txt
+++ b/tests/golden/test_reflection/test_show_effect.txt
@@ -1,0 +1,8 @@
+Reads:
+  { A : (i,k) for (j,k) in Z if
+    0 <= j and j < M and (0 <= k and k < K) }
+  { B : (k,j) for (j,k) in Z if
+    0 <= j and j < M and (0 <= k and k < K) }
+Reduces:
+    { C : (i,j) for (j,k) in Z if
+    0 <= j and j < M and (0 <= k and k < K) }

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from exo import proc, DRAM, QAST
 from exo.stdlib.scheduling import *
 
+
 # ------- Reflection tests ---------
 
 
@@ -64,7 +65,7 @@ def test_find_outer_loop():
 
 def get_loop_nest_info(p, pattern):
     loops = p.get_ast(pattern)
-    if loops == None:
+    if loops is None:
         return []
     assert isinstance(loops, list) and len(loops) > 0
     assert isinstance(loops[0], QAST.Stmt), "must call with ... #_ pattern"
@@ -130,3 +131,9 @@ def test_get_no_loop_info():
 
     info = get_loop_nest_info(sgemm, "for abc in _: _ #0")
     assert info == []
+
+
+def test_show_effect(golden):
+    sgemm = new_sgemm()
+
+    assert sgemm.show_effect("for j in _: _") == golden


### PR DESCRIPTION
A necessary step on the way to re-working `SubstArgs` and friends as cursor-y rewrites.