### PR TITLE
Add -arch=arm64 when targeting neon

### DIFF
--- a/apps/aarch64/sgemm/build.sh
+++ b/apps/aarch64/sgemm/build.sh
@@ -13,7 +13,7 @@ if [ "$1" = "update" ]; then
 fi
 
 # set up cmake build
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64
 
 # do the build
 cmake --build build --verbose


### PR DESCRIPTION
Cmake was putting `-arch=x86_64` by default and was causing compile error on my machine