### PR TITLE
Add depfile support to CMake rules

### DIFF
--- a/src/exo/cmake/AddExoLibrary.cmake
+++ b/src/exo/cmake/AddExoLibrary.cmake
@@ -10,7 +10,7 @@ function(add_exo_library)
     list(APPEND source_files "${src}")
   endforeach ()
 
-  set(intdir "${CMAKE_CURRENT_BINARY_DIR}/${ARG_NAME}.exo")
+  set(intdir "${ARG_NAME}.exo")
   set(files "${intdir}/${ARG_NAME}.c" "${intdir}/${ARG_NAME}.h")
 
   list(TRANSFORM ARG_PYTHONPATH PREPEND "--modify;PYTHONPATH=path_list_append:")
@@ -21,10 +21,12 @@ function(add_exo_library)
             $<TARGET_FILE:Exo::compiler> -o "${intdir}" --stem "${ARG_NAME}"
             ${source_files}
     DEPENDS ${source_files}
+    DEPFILE "${intdir}/${ARG_NAME}.d"
     VERBATIM
   )
 
+  list(TRANSFORM files PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
   add_library(${ARG_NAME} ${files})
   add_library(${PROJECT_NAME}::${ARG_NAME} ALIAS ${ARG_NAME})
-  target_include_directories(${ARG_NAME} PUBLIC "$<BUILD_INTERFACE:${intdir}>")
+  target_include_directories(${ARG_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${intdir}>")
 endfunction()

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -56,8 +56,9 @@ def write_depfile(outdir, stem):
     h_file = outdir / f"{stem}.h"
     depfile = outdir / f"{stem}.d"
 
-    sep = "\\\n  "
-    contents = f"{c_file} {h_file} : {sep.join(modules)}"
+    sep = " \\\n  "
+    deps = sep.join(sorted(modules))
+    contents = f"{c_file} {h_file} : {deps}"
 
     depfile.write_text(contents)
 


### PR DESCRIPTION
This PR adds support to `exocc` for writing out a _depfile_. This is used to inform build systems about dependencies that are discovered while processing a file. Without this, missing dependencies could cause incremental builds to fail.

For a simple example, support `my_kernel.py` imports `common.py`. Then the rule for generating `my_kernel.{c,h}` using `exocc` has to know to re-run when `common.py` is changed. Not so straightforward when it isn't mentioned on the command line.

For a more complex example, consider something like this:

```
if something:
  import avx2 as Machine
else:
  import neon as Machine
```

Now there's really no way for the build system to guess which one is relevant! It has to be _told_, and that's what the depfile does.

Concretely, this creates an extra `my_kernel.d` file which contains a Makefile fragment listing the discovered dependencies in a format that several build systems (including Make and Ninja) understand. This is wired up to CMake as well, so downstream users automatically reap these benefits.