### PR TITLE
Remove knowledge of Procedures from internal cursors

### DIFF
--- a/src/exo/API.py
+++ b/src/exo/API.py
@@ -230,7 +230,7 @@ class Procedure(ProcedureBase):
         """
         Return a BlockCursor selecting the entire body of the Procedure
         """
-        impl = internal_cursors.Cursor.root(self).body()
+        impl = internal_cursors.Cursor.create(self).body()
         return API_cursors.new_Cursor(impl)
 
     def find(self, pattern, many=False):

--- a/src/exo/API.py
+++ b/src/exo/API.py
@@ -217,7 +217,7 @@ class Procedure(ProcedureBase):
     def show_effect(self, stmt_pattern):
         if match := match_pattern(self, stmt_pattern, call_depth=1, default_match_no=0):
             assert len(match[0]) == 1, "Must match single statements"
-            return str(match[0][0]._node().eff)
+            return str(match[0][0]._node.eff)
         raise SchedulingError("failed to find statement", pattern=stmt_pattern)
 
     def is_instr(self):
@@ -286,23 +286,6 @@ class Procedure(ProcedureBase):
     def find_all(self, pattern):
         return self.find(pattern, many=True)
 
-    def _TEST_find_cursors(self, pattern):
-        cursors = match_pattern(self, pattern, call_depth=1)
-        assert isinstance(cursors, list)
-        if not cursors:
-            raise SchedulingError("failed to find matches", pattern=pattern)
-        return cursors
-
-    def _TEST_find_stmt(self, pattern):
-        curs = self._TEST_find_cursors(pattern)
-        assert len(curs) == 1
-        curs = curs[0]
-        if len(curs) != 1:
-            raise SchedulingError(
-                "pattern did not match a single statement", pattern=pattern
-            )
-        return curs[0]
-
     def get_ast(self, pattern=None):
         if pattern is None:
             return LoopIR_to_QAST(self._loopir_proc).result()
@@ -316,7 +299,7 @@ class Procedure(ProcedureBase):
             return None
 
         return [
-            LoopIR_to_QAST(node._node()).result() for block in match for node in block
+            LoopIR_to_QAST(node._node).result() for block in match for node in block
         ]
 
     # ---------------------------------------------- #

--- a/src/exo/API_cursors.py
+++ b/src/exo/API_cursors.py
@@ -123,9 +123,9 @@ class Cursor:
         Raises InvalidCursorError if no parent exists
         """
         impl_parent = self._impl.parent()
-        if isinstance(impl_parent._node(), LoopIR.w_access):
+        if isinstance(impl_parent._node, LoopIR.w_access):
             impl_parent = impl_parent.parent()
-        elif isinstance(impl_parent._node(), LoopIR.proc):
+        elif isinstance(impl_parent._node, LoopIR.proc):
             return InvalidCursor()
         return new_Cursor(impl_parent)
 
@@ -406,7 +406,7 @@ class AssignCursor(StmtCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node.name
 
     def idx(self) -> ExprListCursor:
         return ExprListCursor(self._impl._child_block("idx"))
@@ -422,7 +422,7 @@ class ReduceCursor(StmtCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node.name
 
     def idx(self) -> ExprListCursor:
         return ExprListCursor(self._impl._child_block("idx"))
@@ -438,10 +438,10 @@ class AssignConfigCursor(StmtCursor):
     """
 
     def config(self) -> Config:
-        return self._impl._node().config
+        return self._impl._node.config
 
     def field(self) -> str:
-        return self._impl._node().field
+        return self._impl._node.field
 
     def rhs(self) -> ExprCursor:
         return new_Cursor(self._impl._child_node("rhs"))
@@ -492,7 +492,7 @@ class ForSeqCursor(StmtCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().iter
+        return self._impl._node.iter
 
     def hi(self) -> ExprCursor:
         return new_Cursor(self._impl._child_node("hi"))
@@ -510,10 +510,10 @@ class AllocCursor(StmtCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node.name
 
     def mem(self) -> Optional[Memory]:
-        return self._impl._node().mem
+        return self._impl._node.mem
 
 
 class CallCursor(StmtCursor):
@@ -525,7 +525,7 @@ class CallCursor(StmtCursor):
     """
 
     def subproc(self):
-        return API.Procedure(self._impl._node().f)
+        return API.Procedure(self._impl._node.f)
 
     def args(self) -> ExprListCursor:
         return ExprListCursor(self._impl._child_block("args"))
@@ -540,7 +540,7 @@ class WindowStmtCursor(StmtCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node.name
 
     def winexpr(self) -> ExprCursor:
         return WindowExprCursor(self._impl._child_node("rhs"))
@@ -560,7 +560,7 @@ class ReadCursor(ExprCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node.name
 
     def idx(self) -> ExprListCursor:
         return ExprListCursor(self._impl._child_block("idx"))
@@ -573,10 +573,10 @@ class ReadConfigCursor(ExprCursor):
     """
 
     def config(self) -> Config:
-        return self._impl._node().config
+        return self._impl._node.config
 
     def field(self) -> str:
-        return self._impl._node().field
+        return self._impl._node.field
 
 
 class LiteralCursor(ExprCursor):
@@ -590,7 +590,7 @@ class LiteralCursor(ExprCursor):
     """
 
     def value(self) -> Any:
-        n = self._impl._node()
+        n = self._impl._node
         assert (
             (n.type == T.bool and type(n.val) == bool)
             or (n.type.is_indexable() and type(n.val) == int)
@@ -618,7 +618,7 @@ class BinaryOpCursor(ExprCursor):
     """
 
     def op(self) -> str:
-        return self._impl._node().op
+        return self._impl._node.op
 
     def lhs(self) -> ExprCursor:
         return new_Cursor(self._impl._child_node("lhs"))
@@ -634,7 +634,7 @@ class BuiltInFunctionCursor(ExprCursor):
     """
 
     def name(self) -> str:
-        return self._impl._node().f.name()
+        return self._impl._node.f.name()
 
     def args(self) -> ExprListCursor:
         return ExprListCursor(self._impl._child_block("args"))
@@ -652,11 +652,11 @@ class WindowExprCursor(ExprCursor):
     """
 
     def name(self) -> str:
-        return self._impl._node().f.name()
+        return self._impl._node.f.name()
 
     def idx(self) -> List:
         def convert_w(w):
-            if isinstance(w._node(), LoopIR.Interval):
+            if isinstance(w._node, LoopIR.Interval):
                 return (
                     new_Cursor(w._child_node("lo")),
                     new_Cursor(w._child_node("hi")),
@@ -676,10 +676,10 @@ class StrideExprCursor(ExprCursor):
     """
 
     def name(self) -> Sym:
-        return self._impl._node().name
+        return self._impl._node.name
 
     def dim(self) -> int:
-        return self._impl._node().dim
+        return self._impl._node.dim
 
 
 # --------------------------------------------------------------------------- #
@@ -740,18 +740,18 @@ def new_Cursor(impl):
     elif isinstance(impl, C.Block):
         # TODO: Rename internal Cursor type to Sequence?
         assert len(impl) > 0
-        n0 = impl[0]._node()
+        n0 = impl[0]._node
         if isinstance(n0, LoopIR.stmt):
-            assert all(isinstance(c._node(), LoopIR.stmt) for c in impl)
+            assert all(isinstance(c._node, LoopIR.stmt) for c in impl)
             return BlockCursor(impl)
         elif isinstance(n0, LoopIR.expr):
-            assert all(isinstance(c._node(), LoopIR.expr) for c in impl)
+            assert all(isinstance(c._node, LoopIR.expr) for c in impl)
             return ExprListCursor(impl)
         else:
             assert False, "bad case"
 
     elif isinstance(impl, C.Node):
-        n = impl._node()
+        n = impl._node
 
         # statements
         if isinstance(n, LoopIR.Assign):

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -746,8 +746,8 @@ def insert_pass(proc, gap_cursor):
         -->
         `s1 ; pass ; s2`
     """
-    p, _fwd = scheduling.DoInsertPass(gap_cursor._impl)
-    return p
+    ir, _fwd = scheduling.DoInsertPass(gap_cursor._impl)
+    return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([])
@@ -777,8 +777,8 @@ def reorder_stmts(proc, block_cursor):
     s1 = block_cursor[0]._impl
     s2 = block_cursor[1]._impl
 
-    proc, _fwd = scheduling.DoReorderStmt(s1, s2)
-    return proc
+    ir, _fwd = scheduling.DoReorderStmt(s1, s2)
+    return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([ExprCursorA(many=True)])
@@ -1040,8 +1040,8 @@ def delete_config(proc, stmt_cursor):
     rewrite:
         `s1 ; config.field = _ ; s3    ->    s1 ; s3`
     """
-    p, _fwd = scheduling.DoDeleteConfig(ic.Cursor.create(proc), stmt_cursor._impl)
-    return p
+    ir, _fwd = scheduling.DoDeleteConfig(ic.Cursor.create(proc), stmt_cursor._impl)
+    return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([GapCursorA, ConfigA, ConfigFieldA, NewExprA("gap_cursor")])
@@ -1501,8 +1501,8 @@ def mult_loops(proc, nested_loops, new_iter_name):
         `for k in seq(0,e*c):`      # k is new_iter_name
         `    s[ i -> k/c, j -> k%c ]`
     """
-    p, _fwd = scheduling.DoProductLoop(nested_loops._impl, new_iter_name)
-    return p
+    ir, _fwd = scheduling.DoProductLoop(nested_loops._impl, new_iter_name)
+    return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([ForSeqCursorA, PosIntA])
@@ -1527,8 +1527,8 @@ def cut_loop(proc, loop, cut_point):
         `for i in seq(0,n-cut):`
         `    s[i -> i+cut]`
     """
-    p, _fwd = scheduling.DoPartitionLoop(loop._impl, cut_point)
-    return p
+    ir, _fwd = scheduling.DoPartitionLoop(loop._impl, cut_point)
+    return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([NestedForSeqCursorA])
@@ -1734,7 +1734,8 @@ def fuse(proc, stmt1, stmt2):
     if isinstance(stmt1, PC.IfCursor):
         return scheduling.DoFuseIf(proc_c, s1, s2).result()
     else:
-        return scheduling.DoFuseLoop(proc_c, s1, s2)
+        ir, _fwd = scheduling.DoFuseLoop(proc_c, s1, s2)
+        return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([ForSeqCursorA])

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -698,7 +698,7 @@ def simplify(proc):
     to constants and eliminate dead branches and loops. Uses branch
     conditions to simplify expressions inside the branches.
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoSimplify(proc_c).result()
 
 
@@ -757,7 +757,7 @@ def delete_pass(proc):
 
     Delete all `pass` statements in the procedure.
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoDeletePass(proc_c).result()
 
 
@@ -813,7 +813,7 @@ def commute_expr(proc, expr_cursors):
             "can commute by commute_expr()"
         )
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoCommuteExpr(proc_c, exprs).result()
 
 
@@ -847,7 +847,7 @@ def bind_expr(proc, expr_cursors, new_name, cse=False):
             "can be bound by bind_expr()"
         )
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoBindExpr(proc_c, new_name, exprs, cse).result()
 
 
@@ -861,7 +861,7 @@ def extract_subproc(proc, subproc_name, body_stmt):
     """
     Documentation TODO
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = body_stmt._impl
     passobj = scheduling.DoExtractMethod(proc_c, subproc_name, stmt)
     return (passobj.result(), passobj.subproc())
@@ -877,7 +877,7 @@ def inline(proc, call_cursor):
                           whose body we want to inline
     """
     call_stmt = call_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoInline(proc_c, call_stmt).result()
 
 
@@ -926,7 +926,7 @@ def call_eqv(proc, call_cursor, eqv_proc):
     call_stmt = call_cursor._impl
     new_loopir = eqv_proc._loopir_proc
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     rewrite_pass = scheduling.DoCallSwap(proc_c, call_stmt, new_loopir)
     mod_config = rewrite_pass.mod_eq()
     return rewrite_pass.result(mod_config=mod_config)
@@ -951,7 +951,7 @@ def set_precision(proc, name, typ):
         `name : _[...]    ->    name : typ[...]`
     """
     name, count = name
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoSetTypAndMem(proc_c, name, count, basetyp=typ).result()
 
 
@@ -969,7 +969,7 @@ def set_window(proc, name, is_window=True):
         `name : R[...]    ->    name : [R][...]`
     """
     name, count = name
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoSetTypAndMem(proc_c, name, count, win=is_window).result()
 
 
@@ -986,7 +986,7 @@ def set_memory(proc, name, memory_type):
         `name : _ @ _    ->    name : _ @ mem`
     """
     name, count = name
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     return scheduling.DoSetTypAndMem(proc_c, name, count, mem=memory_type).result()
 
 
@@ -1022,7 +1022,7 @@ def bind_config(proc, var_cursor, config, field):
             f"to match type of Config variable ({cfg_f_type})"
         )
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     rewrite_pass = scheduling.DoBindConfig(proc_c, config, field, var_cursor._impl)
     mod_config = rewrite_pass.mod_eq()
     return rewrite_pass.result(mod_config=mod_config)
@@ -1040,7 +1040,7 @@ def delete_config(proc, stmt_cursor):
     rewrite:
         `s1 ; config.field = _ ; s3    ->    s1 ; s3`
     """
-    p, _fwd = scheduling.DoDeleteConfig(ic.Cursor.root(proc), stmt_cursor._impl)
+    p, _fwd = scheduling.DoDeleteConfig(ic.Cursor.create(proc), stmt_cursor._impl)
     return p
 
 
@@ -1067,7 +1067,7 @@ def write_config(proc, gap_cursor, config, field, rhs):
         before = False
     stmt = stmtc._impl
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     rewrite_pass = scheduling.DoConfigWrite(
         proc_c, stmt, config, field, rhs, before=before
     )
@@ -1102,7 +1102,7 @@ def expand_dim(proc, buf_cursor, alloc_dim, indexing_expr, unsafe_disable_checks
         The provided dimension size is checked for positivity and the
         provided indexing expression is checked to make sure it is in-bounds
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = buf_cursor._impl
     new_proc_c = scheduling.DoExpandDim(proc_c, stmt, alloc_dim, indexing_expr).result()
     if not unsafe_disable_checks:
@@ -1126,7 +1126,7 @@ def rearrange_dim(proc, buf_cursor, permute_vector):
         (with permute_vector = [2,0,1])
         `x : T[N,M,K]` -> `x : T[K,N,M]`
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = buf_cursor._impl
     # extra sanity check
     N = len(stmt._node().type.hi)
@@ -1160,7 +1160,7 @@ def bound_alloc(proc, buf_cursor, new_bounds, unsafe_disable_checks=False):
         The new bounds are checked to make sure they don't cause any
         out-of-bounds memory accesses
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = buf_cursor._impl
     if len(stmt._node().type.hi) != len(new_bounds):
         raise ValueError(
@@ -1200,7 +1200,7 @@ def divide_dim(proc, alloc_cursor, dim_idx, quotient):
     """
     if quotient == 1:
         raise ValueError("why are you trying to divide by 1?")
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = alloc_cursor._impl
     if not (0 <= dim_idx < len(stmt._node().type.shape())):
         raise ValueError(f"Cannot divide out-of-bounds dimension index {dim_idx}")
@@ -1229,7 +1229,7 @@ def mult_dim(proc, alloc_cursor, hi_dim_idx, lo_dim_idx):
         `x : R[4*n, m]`
         `x[4*i + k, j] = ...`
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = alloc_cursor._impl
     for dim_idx in [hi_dim_idx, lo_dim_idx]:
         if not (0 <= dim_idx < len(stmt._node().type.shape())):
@@ -1258,7 +1258,7 @@ def lift_alloc(proc, alloc_cursor, n_lifts=1):
         `for i in _:`
         `    ...`
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = alloc_cursor._impl
 
     return scheduling.DoLiftAllocSimple(proc_c, stmt, n_lifts).result()
@@ -1291,7 +1291,7 @@ def autolift_alloc(
         `for i in _:`
         `    ...`
     """
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     stmt = alloc_cursor._impl
 
     return scheduling.DoLiftAlloc(proc_c, stmt, n_lifts, mode, size, keep_dims).result()
@@ -1319,7 +1319,7 @@ def reuse_buffer(proc, buf_cursor, replace_cursor):
     """
     buf_s = buf_cursor._impl
     rep_s = replace_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoDataReuse(proc_c, buf_s, rep_s).result()
 
@@ -1337,7 +1337,7 @@ def inline_window(proc, winstmt_cursor):
         `y = x[...] ; s` -> `s[ y -> x[...] ]`
     """
     stmt = winstmt_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoInlineWindow(proc_c, stmt).result()
 
@@ -1352,7 +1352,7 @@ def stage_window(proc, expr_cursor, win_name, memory=None):
     Should it resemble `stage_mem` instead?
     """
     e = expr_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoStageWindow(proc_c, win_name, memory, e).result()
 
@@ -1402,7 +1402,7 @@ def stage_mem(proc, block_cursor, win_expr, new_buf_name, accum=False):
     buf_name, w_exprs = win_expr
     stmt_start = block_cursor[0]._impl
     stmt_end = block_cursor[-1]._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoStageMem(
         proc_c,
@@ -1468,7 +1468,7 @@ def divide_loop(proc, loop_cursor, div_const, new_iters, tail="guard", perfect=F
         raise ValueError("why are you trying to split by 1?")
 
     stmt = loop_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoSplit(
         proc_c,
@@ -1562,7 +1562,7 @@ def reorder_loops(proc, nested_loops):
     if len(stmt_c.body()) != 1 or not isinstance(stmt_c.body()[0]._node(), LoopIR.Seq):
         raise ValueError(f"expected loop directly inside of {stmt_c._node().iter} loop")
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoLiftScope(proc_c, stmt_c.body()[0]).result()
 
@@ -1620,7 +1620,7 @@ def merge_writes(proc, block_cursor):
             "expected the two statements' right hand sides to have the same type."
         )
 
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoMergeWrites(
         proc_c, block_cursor[0]._impl, block_cursor[1]._impl
@@ -1655,7 +1655,7 @@ def fission(proc, gap_cursor, n_lifts=1):
     if not (stmtc := gap_cursor.before()) or not gap_cursor.after():
         raise ValueError("expected cursor to point to " "a gap between statements")
     stmt = stmtc._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoFissionAfterSimple(proc_c, stmt, n_lifts).result()
 
@@ -1689,7 +1689,7 @@ def autofission(proc, gap_cursor, n_lifts=1):
     if not (stmtc := gap_cursor.before()) or not gap_cursor.after():
         raise ValueError("expected cursor to point to " "a gap between statements")
     stmt = stmtc._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoFissionLoops(proc_c, stmt, n_lifts).result()
 
@@ -1730,7 +1730,7 @@ def fuse(proc, stmt1, stmt2):
         )
     s1 = stmt1._impl
     s2 = stmt2._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
     if isinstance(stmt1, PC.IfCursor):
         return scheduling.DoFuseIf(proc_c, s1, s2).result()
     else:
@@ -1755,7 +1755,7 @@ def remove_loop(proc, loop_cursor):
     """
 
     stmt = loop_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoRemoveLoop(proc_c, stmt).result()
 
@@ -1788,7 +1788,7 @@ def add_loop(proc, block_cursor, iter_name, hi_expr, guard=False):
         raise NotImplementedError("TODO: support blocks of size > 1")
 
     stmt = block_cursor[0]._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoAddLoop(proc_c, stmt, iter_name, hi_expr, guard).result()
 
@@ -1811,7 +1811,7 @@ def unroll_loop(proc, loop_cursor):
     """
 
     stmt = loop_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoUnroll(proc_c, stmt).result()
 
@@ -1844,7 +1844,7 @@ def lift_scope(proc, scope_cursor):
         `        s2`
     """
     stmt_c = scope_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoLiftScope(proc_c, stmt_c).result()
 
@@ -1872,7 +1872,7 @@ def assert_if(proc, if_cursor, cond):
         `s1`
     """
     stmt = if_cursor._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoAssertIf(proc_c, stmt, cond).result()
 
@@ -1909,7 +1909,7 @@ def specialize(proc, block_cursor, conds):
         raise NotImplementedError("TODO: support blocks of size > 1")
 
     stmt = block_cursor[0]._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoSpecialize(proc_c, stmt, conds).result()
 
@@ -1926,7 +1926,7 @@ def add_unsafe_guard(proc, block_cursor, var_expr):
     This operation is deprecated, and will be removed soon.
     """
     stmt = block_cursor._impl[0]
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoAddUnsafeGuard(proc_c, stmt, var_expr).result()
 
@@ -1947,6 +1947,6 @@ def bound_and_guard(proc, loop):
     This currently only works when e is of the form x % n
     """
     stmt = loop._impl
-    proc_c = ic.Cursor.root(proc)
+    proc_c = ic.Cursor.create(proc)
 
     return scheduling.DoBoundAndGuard(proc_c, stmt).result()

--- a/src/exo/LoopIR_pprint.py
+++ b/src/exo/LoopIR_pprint.py
@@ -571,7 +571,7 @@ def _print_cursor(cur):
             "Cursor printing is only implemented for procs and statements"
         )
 
-    root_cur = Cursor.root(cur._proc())
+    root_cur = Cursor.root(cur.get_root())
     lines = _print_cursor_proc(root_cur, cur, PrintEnv(), "")
     code = _format_code("\n".join(lines))
     # need to use "..." for Python parsing, but unquoted ellipses are prettier

--- a/src/exo/LoopIR_pprint.py
+++ b/src/exo/LoopIR_pprint.py
@@ -571,7 +571,7 @@ def _print_cursor(cur):
             "Cursor printing is only implemented for procs and statements"
         )
 
-    root_cur = Cursor.root(cur.get_root())
+    root_cur = Cursor.create(cur.get_root())
     lines = _print_cursor_proc(root_cur, cur, PrintEnv(), "")
     code = _format_code("\n".join(lines))
     # need to use "..." for Python parsing, but unquoted ellipses are prettier

--- a/src/exo/LoopIR_pprint.py
+++ b/src/exo/LoopIR_pprint.py
@@ -564,9 +564,7 @@ def _print_w_access(node, env: PrintEnv) -> str:
 
 
 def _print_cursor(cur):
-    if isinstance(cur, Node) and not isinstance(
-        cur._node(), (LoopIR.proc, LoopIR.stmt)
-    ):
+    if isinstance(cur, Node) and not isinstance(cur._node, (LoopIR.proc, LoopIR.stmt)):
         raise NotImplementedError(
             "Cursor printing is only implemented for procs and statements"
         )
@@ -582,7 +580,7 @@ def _print_cursor(cur):
 def _print_cursor_proc(
     cur: Node, target: Cursor, env: PrintEnv, indent: str
 ) -> list[str]:
-    p = cur._node()
+    p = cur._node
     assert isinstance(p, LoopIR.proc)
 
     match_comment = "  # <-- NODE" if cur == target else ""
@@ -657,7 +655,7 @@ def _print_cursor_block(
 def _print_cursor_stmt(
     cur: Node, target: Cursor, env: PrintEnv, indent: str
 ) -> list[str]:
-    stmt = cur._node()
+    stmt = cur._node
 
     if isinstance(stmt, LoopIR.If):
         cond = _print_expr(stmt.cond, env)
@@ -679,7 +677,6 @@ def _print_cursor_stmt(
 
     else:
         lines = _print_stmt(stmt, env, indent)
-
     if cur == target:
         lines[0] = f"{lines[0]}  # <-- NODE"
 

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -50,7 +50,7 @@ from .pattern_match import match_pattern
 
 class Cursor_Rewrite(LoopIR_Rewrite):
     def __init__(self, proc_cursor):
-        self.provenance = proc_cursor.proc()
+        self.provenance = proc_cursor.get_root()
         self.orig_proc = proc_cursor
         self.proc = self.apply_proc(proc_cursor)
 
@@ -239,7 +239,7 @@ def DoReorderStmt(f_cursor, s_cursor):
         raise SchedulingError(
             "expected the second statement to be directly after the first"
         )
-    orig_proc = f_cursor.proc()
+    orig_proc = f_cursor.get_root()
     Check_ReorderStmts(orig_proc._loopir_proc, f_cursor._node(), s_cursor._node())
     p, fwd = s_cursor.as_block()._move(f_cursor.before())
     return _fixup_effects(orig_proc, p, fwd)
@@ -254,7 +254,7 @@ def DoPartitionLoop(stmt, partition_by):
     new_hi = LoopIR.BinOp("-", s.hi, part_by, T.int, s.srcinfo)
     try:
         Check_IsPositiveExpr(
-            stmt.proc()._loopir_proc,
+            stmt.get_root()._loopir_proc,
             [s],
             LoopIR.BinOp(
                 "+", new_hi, LoopIR.Const(1, T.int, s.srcinfo), T.int, s.srcinfo
@@ -278,7 +278,7 @@ def DoPartitionLoop(stmt, partition_by):
     loop2 = s.update(iter=iter2, hi=new_hi, body=body2, eff=None)
 
     p, fwd = stmt._replace([loop1, loop2])
-    return _fixup_effects(stmt.proc(), p, fwd)
+    return _fixup_effects(stmt.get_root(), p, fwd)
 
 
 def _compose(f, g):
@@ -297,7 +297,7 @@ def _replace_pats(p, fwd, c, pat, repl):
 
 
 def DoProductLoop(outer_loop, new_name):
-    orig_proc = outer_loop.proc()
+    orig_proc = outer_loop.get_root()
 
     body = outer_loop.body()
     outer_loop_ir = outer_loop._node()
@@ -2359,7 +2359,7 @@ class DoFissionAfterSimple:
         self.tgt_stmt = stmt_cursor._node()
         assert isinstance(self.tgt_stmt, LoopIR.stmt)
         assert is_pos_int(n_lifts)
-        self.provenance = proc_cursor.proc()
+        self.provenance = proc_cursor.get_root()
         self.orig_proc = proc_cursor._node()
         self.n_lifts = n_lifts
 
@@ -2480,7 +2480,7 @@ class DoFissionLoops:
         self.tgt_stmt = stmt_cursor._node()
         assert isinstance(self.tgt_stmt, LoopIR.stmt)
         assert is_pos_int(n_lifts)
-        self.provenance = proc_cursor.proc()
+        self.provenance = proc_cursor.get_root()
         self.orig_proc = proc_cursor._node()
         self.n_lifts = n_lifts
 
@@ -2701,7 +2701,7 @@ def DoFuseLoop(proc_cursor, f_cursor, s_cursor):
 
     Check_FissionLoop(proc._loopir_proc, loop, body1, body2)
     proc = InferEffects(proc._loopir_proc).result()
-    return api.Procedure(proc, _provenance_eq_Procedure=proc_cursor.proc())
+    return api.Procedure(proc, _provenance_eq_Procedure=proc_cursor.get_root())
 
 
 class DoFuseIf(Cursor_Rewrite):

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -3058,7 +3058,7 @@ class DoSimplify(Cursor_Rewrite):
     def __init__(self, proc_cursor):
         self.facts = ChainMap()
         new_procedure = _DoNormalize(proc_cursor).result()
-        self.proc_cursor = ic.Cursor.root(new_procedure)
+        self.proc_cursor = ic.Cursor.create(new_procedure)
 
         super().__init__(self.proc_cursor)
 

--- a/src/exo/internal_cursors.py
+++ b/src/exo/internal_cursors.py
@@ -106,7 +106,7 @@ class Cursor(ABC):
     # ------------------------------------------------------------------------ #
 
     @staticmethod
-    def root(obj: object):
+    def create(obj: object):
         return Node(weakref.ref(obj), [])
 
     # ------------------------------------------------------------------------ #

--- a/src/exo/pattern_match.py
+++ b/src/exo/pattern_match.py
@@ -58,7 +58,7 @@ def get_match_no(pattern_str: str) -> Optional[int]:
 
 def match_pattern(context, pattern_str, call_depth=0, default_match_no=None):
     if not isinstance(context, Cursor):
-        context = Cursor.root(context)
+        context = Cursor.create(context)
 
     # break-down pattern_str for possible #<num> post-fix
     if match := re.search(r"^([^#]+)#(\d+)\s*$", pattern_str):

--- a/src/exo/pattern_match.py
+++ b/src/exo/pattern_match.py
@@ -152,14 +152,14 @@ class PatternMatch:
 
     def find_expr(self, pat, cur):
         # try to match
-        if self.match_e(pat, cur._node()):
+        if self.match_e(pat, cur._node):
             self._add_result(cur)
 
         for child in cur.children():
             self.find_expr(pat, child)
 
     def find_stmts(self, pats, cur: Node):
-        if isinstance(cur._node(), LoopIR.proc):
+        if isinstance(cur._node, LoopIR.proc):
             return self.find_stmts_in_block(pats, cur.body())
 
         return self.find_stmts_in_block(pats, cur.as_block())
@@ -177,10 +177,10 @@ class PatternMatch:
 
         # first, look for any subsequences of statements in the first
         # statement of the sequence `stmts`
-        if isinstance(curs[0]._node(), LoopIR.If):
+        if isinstance(curs[0]._node, LoopIR.If):
             self.find_stmts_in_block(pats, curs[0].body())
             self.find_stmts_in_block(pats, curs[0].orelse())
-        elif isinstance(curs[0]._node(), LoopIR.Seq):
+        elif isinstance(curs[0]._node, LoopIR.Seq):
             self.find_stmts_in_block(pats, curs[0].body())
         else:
             pass  # other forms of statement do not contain stmt blocks
@@ -214,7 +214,7 @@ class PatternMatch:
         # first ensure that the pattern and statement
         # are the same constructor
 
-        stmt = cur._node()
+        stmt = cur._node
 
         if not isinstance(
             stmt, (LoopIR.WindowStmt,) + tuple(_PAST_to_LoopIR[type(pat)])

--- a/tests/test_internal_cursors.py
+++ b/tests/test_internal_cursors.py
@@ -340,7 +340,7 @@ def test_cursor_lifetime():
     gc.collect()
 
     with pytest.raises(InvalidCursorError, match="underlying proc was destroyed"):
-        cur.proc()
+        cur.get_root()
 
     # TODO: The WeakKeyDictionary-ies in other modules seem to keep the IR alive as
     #   they keep references to them in the values.
@@ -590,11 +590,11 @@ def _debug_print_forwarding(x, fwd):
     fx = fwd(x)
     print(x._path)
     print(_print_cursor(x))
-    print(x._proc())
+    print(x._root())
     print("-----------")
     print(fx._path)
     print(_print_cursor(fx))
-    print(fx._proc())
+    print(fx._root())
     print()
     print()
 

--- a/tests/test_internal_cursors.py
+++ b/tests/test_internal_cursors.py
@@ -50,12 +50,12 @@ def proc_bar():
 
 
 def test_get_root(proc_foo):
-    cursor = Cursor.root(proc_foo)
+    cursor = Cursor.create(proc_foo)
     assert cursor._node() is proc_foo.INTERNAL_proc()
 
 
 def test_get_child(proc_foo):
-    cursor = Cursor.root(proc_foo).children()
+    cursor = Cursor.create(proc_foo).children()
     cursor = next(iter(cursor))
     assert cursor._node() is proc_foo.INTERNAL_proc().body[0]
 
@@ -84,13 +84,13 @@ def test_gap_insert_pass(proc_foo, golden):
 
 
 def test_insert_root_front(proc_foo, golden):
-    c = Cursor.root(proc_foo)
+    c = Cursor.create(proc_foo)
     foo2, _ = c.body().before()._insert([LoopIR.Pass(None, c._node().srcinfo)])
     assert str(foo2) == golden
 
 
 def test_insert_root_end(proc_foo, golden):
-    c = Cursor.root(proc_foo)
+    c = Cursor.create(proc_foo)
     foo2, _ = c.body().after()._insert([LoopIR.Pass(None, c._node().srcinfo)])
     assert str(foo2) == golden
 
@@ -182,7 +182,7 @@ def test_cursor_move(proc_foo):
 
 def test_cursor_move_invalid(proc_foo):
     # Edge cases near the root
-    c = Cursor.root(proc_foo)
+    c = Cursor.create(proc_foo)
     with pytest.raises(InvalidCursorError, match="cannot move root cursor"):
         c.next()
 
@@ -306,13 +306,13 @@ def test_cursor_forward_expr_deep():
 
 
 def test_cursor_loop_bound(proc_foo):
-    c_for_i = Cursor.root(proc_foo).body()[0]
+    c_for_i = Cursor.create(proc_foo).body()[0]
     c_bound = c_for_i._child_node("hi")
     assert isinstance(c_bound._node(), LoopIR.Read)
 
 
 def test_cursor_invalid_child(proc_foo):
-    c = Cursor.root(proc_foo)
+    c = Cursor.create(proc_foo)
 
     # Quick sanity check
     assert c._child_node("body", 0) == c.body()[0]
@@ -441,7 +441,7 @@ def test_forward_lifetime(proc_bar):
     bar_new, fwd = for_j._delete()
     bar_new_weak = weakref.ref(bar_new)
 
-    c = Cursor.root(bar_new).body()[0]
+    c = Cursor.create(bar_new).body()[0]
     assert c._node() is not None
 
     gc.collect()
@@ -488,7 +488,7 @@ def test_block_replace_forward_node(proc_bar, old, new):
 def test_cursor_pretty_print_nodes(proc_bar, golden):
     output = []
 
-    root = Cursor.root(proc_bar)
+    root = Cursor.create(proc_bar)
     output.append(_print_cursor(root))
 
     c = proc_bar._TEST_find_stmt("for i in _: _")

--- a/tests/test_internal_cursors.py
+++ b/tests/test_internal_cursors.py
@@ -5,7 +5,7 @@ import weakref
 
 import pytest
 
-from exo import proc
+from exo import proc, SchedulingError
 from exo.LoopIR import LoopIR, T
 from exo.LoopIR_pprint import _print_cursor
 from exo.internal_cursors import (
@@ -14,8 +14,28 @@ from exo.internal_cursors import (
     InvalidCursorError,
     Node,
 )
+from exo.pattern_match import match_pattern
 from exo.prelude import Sym
 from exo.syntax import size, f32
+
+
+def _find_cursors(ctx, pattern):
+    cursors = match_pattern(ctx, pattern, call_depth=1)
+    assert isinstance(cursors, list)
+    if not cursors:
+        raise SchedulingError("failed to find matches", pattern=pattern)
+    return cursors
+
+
+def _find_stmt(ctx, pattern):
+    curs = _find_cursors(ctx, pattern)
+    assert len(curs) == 1
+    curs = curs[0]
+    if len(curs) != 1:
+        raise SchedulingError(
+            "pattern did not match a single statement", pattern=pattern
+        )
+    return curs[0]
 
 
 @pytest.fixture(scope="session")
@@ -51,33 +71,33 @@ def proc_bar():
 
 def test_get_root(proc_foo):
     cursor = Cursor.create(proc_foo)
-    assert cursor._node() is proc_foo.INTERNAL_proc()
+    assert cursor._node is proc_foo.INTERNAL_proc()
 
 
 def test_get_child(proc_foo):
     cursor = Cursor.create(proc_foo).children()
     cursor = next(iter(cursor))
-    assert cursor._node() is proc_foo.INTERNAL_proc().body[0]
+    assert cursor._node is proc_foo.INTERNAL_proc().body[0]
 
 
 def test_find_cursor(proc_foo):
-    c = proc_foo._TEST_find_cursors("for j in _:_")
+    c = _find_cursors(proc_foo, "for j in _:_")
     assert len(c) == 1
     c = c[0]  # One match
     c = c[0]  # First/only node in the block
 
-    assert c._node() is proc_foo.INTERNAL_proc().body[0].body[0]
+    assert c._node is proc_foo.INTERNAL_proc().body[0].body[0]
 
 
 def test_find_hole_in_middle(proc_bar):
-    c_body_1_5 = proc_bar._TEST_find_cursors("x = 1.0 ; _ ; x = 4.0")[0]
-    for_j = proc_bar._TEST_find_stmt("for j in _: _")
+    c_body_1_5 = _find_cursors(proc_bar, "x = 1.0 ; _ ; x = 4.0")[0]
+    for_j = _find_stmt(proc_bar, "for j in _: _")
     assert c_body_1_5 == for_j.body()[1:5]
 
 
 def test_gap_insert_pass(proc_foo, golden):
-    c = proc_foo._TEST_find_stmt("x = 0.0")
-    assn = c._node()
+    c = _find_stmt(proc_foo, "x = 0.0")
+    assn = c._node
     g = c.after()
     foo2, _ = g._insert([LoopIR.Pass(None, assn.srcinfo)])
     assert str(foo2) == golden
@@ -85,26 +105,26 @@ def test_gap_insert_pass(proc_foo, golden):
 
 def test_insert_root_front(proc_foo, golden):
     c = Cursor.create(proc_foo)
-    foo2, _ = c.body().before()._insert([LoopIR.Pass(None, c._node().srcinfo)])
+    foo2, _ = c.body().before()._insert([LoopIR.Pass(None, c._node.srcinfo)])
     assert str(foo2) == golden
 
 
 def test_insert_root_end(proc_foo, golden):
     c = Cursor.create(proc_foo)
-    foo2, _ = c.body().after()._insert([LoopIR.Pass(None, c._node().srcinfo)])
+    foo2, _ = c.body().after()._insert([LoopIR.Pass(None, c._node.srcinfo)])
     assert str(foo2) == golden
 
 
 def test_block_gaps(proc_bar):
-    c = proc_bar._TEST_find_stmt("for j in _: _")
+    c = _find_stmt(proc_bar, "for j in _: _")
 
     body = c.body()
     assert len(body) == 6
     subset = body[1:4]
     assert len(subset) == 3
 
-    cx1 = proc_bar._TEST_find_stmt("x = 1.0")
-    cx3 = proc_bar._TEST_find_stmt("x = 3.0")
+    cx1 = _find_stmt(proc_bar, "x = 1.0")
+    cx3 = _find_stmt(proc_bar, "x = 3.0")
     assert subset[0] == cx1
     assert subset[2] == cx3
 
@@ -113,7 +133,7 @@ def test_block_gaps(proc_bar):
 
 
 def test_block_sequence_interface(proc_bar):
-    for_j_body = proc_bar._TEST_find_stmt("for j in _: _").body()
+    for_j_body = _find_stmt(proc_bar, "for j in _: _").body()
     assert for_j_body[:] is not for_j_body
     assert for_j_body[:] == for_j_body
     assert len(list(for_j_body)) == 6
@@ -125,7 +145,7 @@ def test_block_sequence_interface(proc_bar):
 
 
 def test_block_delete(proc_bar, golden):
-    c = proc_bar._TEST_find_stmt("for j in _: _")
+    c = _find_stmt(proc_bar, "for j in _: _")
     stmts = c.body()[1:4]
 
     bar2, _ = stmts._delete()
@@ -133,29 +153,29 @@ def test_block_delete(proc_bar, golden):
 
 
 def test_block_replace(proc_bar, golden):
-    c = proc_bar._TEST_find_stmt("for j in _: _")
+    c = _find_stmt(proc_bar, "for j in _: _")
     stmts = c.body()[1:4]
 
-    bar2, _ = stmts._replace([LoopIR.Pass(None, c._node().srcinfo)])
+    bar2, _ = stmts._replace([LoopIR.Pass(None, c._node.srcinfo)])
     assert str(bar2) == golden
 
 
 def test_block_delete_whole_block(proc_bar, golden):
-    c = proc_bar._TEST_find_stmt("for j in _: _")
+    c = _find_stmt(proc_bar, "for j in _: _")
     bar2, _ = c.body()._delete()
     assert str(bar2) == golden
 
 
 def test_node_replace(proc_bar, golden):
-    c = proc_bar._TEST_find_stmt("x = 3.0")
+    c = _find_stmt(proc_bar, "x = 3.0")
     assert isinstance(c, Node)
 
-    bar2, _ = c._replace([LoopIR.Pass(None, c._node().srcinfo)])
+    bar2, _ = c._replace([LoopIR.Pass(None, c._node.srcinfo)])
     assert str(bar2) == golden
 
 
 def test_cursor_move(proc_foo):
-    c = proc_foo._TEST_find_stmt("for j in _:_")
+    c = _find_stmt(proc_foo, "for j in _:_")
 
     c_list = c.body()  # list of j's body
     assert isinstance(c_list, Block)
@@ -164,15 +184,15 @@ def test_cursor_move(proc_foo):
 
     c1 = c_list[0]  # x : f32
     assert c1.parent() == c
-    assert c1._node() is proc_foo.INTERNAL_proc().body[0].body[0].body[0]
+    assert c1._node is proc_foo.INTERNAL_proc().body[0].body[0].body[0]
 
     c2 = c1.next()  # x = 0.0
     assert c2.parent() == c
-    assert c2._node() is proc_foo.INTERNAL_proc().body[0].body[0].body[1]
+    assert c2._node is proc_foo.INTERNAL_proc().body[0].body[0].body[1]
 
     c3 = c1.next(2)  # y : f32
     assert c3.parent() == c
-    assert c3._node() is proc_foo.INTERNAL_proc().body[0].body[0].body[2]
+    assert c3._node is proc_foo.INTERNAL_proc().body[0].body[0].body[2]
 
     _c2_ = c3.prev()
     assert c2 == _c2_
@@ -190,12 +210,12 @@ def test_cursor_move_invalid(proc_foo):
         c.parent()
 
     # Edge cases near expressions
-    c = proc_foo._TEST_find_cursors("m")[0]
+    c = _find_cursors(proc_foo, "m")[0]
     with pytest.raises(InvalidCursorError, match="cursor is not inside block"):
         c.next()
 
     # Edge cases near first statement in block
-    c = proc_foo._TEST_find_stmt("x: f32")
+    c = _find_stmt(proc_foo, "x: f32")
     with pytest.raises(InvalidCursorError, match="cursor is out of range"):
         c.prev()
 
@@ -207,7 +227,7 @@ def test_cursor_move_invalid(proc_foo):
         c.before().before()  # would return node
 
     # Edge cases near last statement in block
-    c = proc_foo._TEST_find_stmt("y = 1.1")
+    c = _find_stmt(proc_foo, "y = 1.1")
     with pytest.raises(InvalidCursorError, match="cursor is out of range"):
         c.next()
 
@@ -228,12 +248,12 @@ def test_cursor_gap(proc_foo):
     #        y: f32
     #                 <- g2
     #        y = 1.1  <- y_assn
-    for_j = proc_foo._TEST_find_stmt("for j in _:_")
-    x_alloc = proc_foo._TEST_find_stmt("x: f32")
-    x_assn = proc_foo._TEST_find_stmt("x = 0.0")
-    y_assn = proc_foo._TEST_find_stmt("y = 1.1")
+    for_j = _find_stmt(proc_foo, "for j in _:_")
+    x_alloc = _find_stmt(proc_foo, "x: f32")
+    x_assn = _find_stmt(proc_foo, "x = 0.0")
+    y_assn = _find_stmt(proc_foo, "y = 1.1")
 
-    assert str(x_alloc._node()) == "x: f32 @ DRAM"
+    assert str(x_alloc._node) == "x: f32 @ DRAM"
 
     g1 = x_alloc.after()
     assert g1 == x_assn.before()
@@ -251,13 +271,13 @@ def test_cursor_gap(proc_foo):
 
 
 def test_cursor_replace_expr(proc_foo, golden):
-    c = proc_foo._TEST_find_cursors("m")[0]
-    foo2, _ = c._replace(LoopIR.Const(42, T.size, c._node().srcinfo))
+    c = _find_cursors(proc_foo, "m")[0]
+    foo2, _ = c._replace(LoopIR.Const(42, T.size, c._node.srcinfo))
     assert str(foo2) == golden
 
 
 def test_cursor_cannot_convert_expr_to_block(proc_foo):
-    c = proc_foo._TEST_find_cursors("m")[0]
+    c = _find_cursors(proc_foo, "m")[0]
     with pytest.raises(InvalidCursorError, match="node is not inside a block"):
         c.as_block()
 
@@ -269,8 +289,8 @@ def test_cursor_replace_expr_deep(golden):
         x = 1.0 * (2.0 + 3.0)
         # x = 1.0 * (4.0 + 3.0)
 
-    c: Node = example._TEST_find_cursors("2.0")[0]
-    four = LoopIR.Const(4.0, T.f32, c._node().srcinfo)
+    c: Node = _find_cursors(example, "2.0")[0]
+    four = LoopIR.Const(4.0, T.f32, c._node.srcinfo)
 
     example_new, _ = c._replace(four)
     assert str(example_new) == golden
@@ -283,32 +303,26 @@ def test_cursor_forward_expr_deep():
         x = 1.0 * (2.0 + 3.0)
         # x = 1.0 * (4.0 + 3.0)
 
-    c2: Node = example._TEST_find_cursors("2.0")[0]
-    four = LoopIR.Const(4.0, T.f32, c2._node().srcinfo)
+    c2: Node = _find_cursors(example, "2.0")[0]
+    four = LoopIR.Const(4.0, T.f32, c2._node.srcinfo)
 
     example_new, fwd = c2._replace(four)
     with pytest.raises(InvalidCursorError, match="cannot forward replaced nodes"):
         fwd(c2)
 
-    assert fwd(example._TEST_find_stmt("x = _")) == example_new._TEST_find_stmt("x = _")
+    assert fwd(_find_stmt(example, "x = _")) == _find_stmt(example_new, "x = _")
     assert (
-        fwd(example._TEST_find_cursors("_ + _")[0])
-        == example_new._TEST_find_cursors("_ + _")[0]
+        fwd(_find_cursors(example, "_ + _")[0])
+        == _find_cursors(example_new, "_ + _")[0]
     )
-    assert (
-        fwd(example._TEST_find_cursors("1.0")[0])
-        == example_new._TEST_find_cursors("1.0")[0]
-    )
-    assert (
-        fwd(example._TEST_find_cursors("3.0")[0])
-        == example_new._TEST_find_cursors("3.0")[0]
-    )
+    assert fwd(_find_cursors(example, "1.0")[0]) == _find_cursors(example_new, "1.0")[0]
+    assert fwd(_find_cursors(example, "3.0")[0]) == _find_cursors(example_new, "3.0")[0]
 
 
 def test_cursor_loop_bound(proc_foo):
     c_for_i = Cursor.create(proc_foo).body()[0]
     c_bound = c_for_i._child_node("hi")
-    assert isinstance(c_bound._node(), LoopIR.Read)
+    assert isinstance(c_bound._node, LoopIR.Read)
 
 
 def test_cursor_invalid_child(proc_foo):
@@ -327,27 +341,6 @@ def test_cursor_invalid_child(proc_foo):
         c._child_node("body", 42)
 
 
-def test_cursor_lifetime():
-    @proc
-    def delete_me():
-        x: f32
-        x = 0.0
-
-    cur = delete_me._TEST_find_stmt("x = _")
-    assert isinstance(cur._node(), LoopIR.Assign)
-
-    del delete_me
-    gc.collect()
-
-    with pytest.raises(InvalidCursorError, match="underlying proc was destroyed"):
-        cur.get_root()
-
-    # TODO: The WeakKeyDictionary-ies in other modules seem to keep the IR alive as
-    #   they keep references to them in the values.
-    # with pytest.raises(InvalidCursorError, match='underlying node was destroyed'):
-    #     cur._node()
-
-
 def test_insert_forward_orelse():
     @proc
     def example_old():
@@ -357,14 +350,14 @@ def test_insert_forward_orelse():
         else:
             x = 2.0
 
-    x1_old = example_old._TEST_find_stmt("x = 1.0")
-    x2_old = example_old._TEST_find_stmt("x = 2.0")
+    x1_old = _find_stmt(example_old, "x = 1.0")
+    x2_old = _find_stmt(example_old, "x = 2.0")
     gap = x1_old.after()
 
-    stmt = [LoopIR.Pass(None, x1_old._node().srcinfo)]
+    stmt = [LoopIR.Pass(None, x1_old._node.srcinfo)]
 
     example_new, fwd = gap._insert(stmt)
-    x2_new = example_new._TEST_find_stmt("x = 2.0")
+    x2_new = _find_stmt(example_new, "x = 2.0")
 
     assert fwd(x2_old) == x2_new
 
@@ -380,11 +373,11 @@ def test_double_insert_forwarding(golden):
             x = 3.0
             # x = 4.0  (added in s3)
 
-    x1_s1 = proc_s1._TEST_find_stmt("x = 1.0")
-    x3_s1 = proc_s1._TEST_find_stmt("x = 3.0")
+    x1_s1 = _find_stmt(proc_s1, "x = 1.0")
+    x3_s1 = _find_stmt(proc_s1, "x = 3.0")
 
-    x2_stmt = x1_s1._node().update(rhs=LoopIR.Const(2.0, T.f32, x1_s1._node().srcinfo))
-    x4_stmt = x1_s1._node().update(rhs=LoopIR.Const(4.0, T.f32, x1_s1._node().srcinfo))
+    x2_stmt = x1_s1._node.update(rhs=LoopIR.Const(2.0, T.f32, x1_s1._node.srcinfo))
+    x4_stmt = x1_s1._node.update(rhs=LoopIR.Const(4.0, T.f32, x1_s1._node.srcinfo))
 
     proc_s2, fwd_12 = x1_s1.after()._insert([x2_stmt])
     proc_s3, fwd_23 = fwd_12(x3_s1).after()._insert([x4_stmt])
@@ -393,16 +386,16 @@ def test_double_insert_forwarding(golden):
     def fwd_13(cur):
         return fwd_23(fwd_12(cur))
 
-    x1_s3 = proc_s3._TEST_find_stmt("x = 1.0")
+    x1_s3 = _find_stmt(proc_s3, "x = 1.0")
     assert fwd_13(x1_s1) == x1_s3
 
-    x3_s3 = proc_s3._TEST_find_stmt("x = 3.0")
+    x3_s3 = _find_stmt(proc_s3, "x = 3.0")
     assert fwd_13(x3_s1) == x3_s3
 
     if_pat = "if _: _\nelse: _"
-    assert fwd_13(proc_s1._TEST_find_stmt(if_pat)) == proc_s3._TEST_find_stmt(if_pat)
+    assert fwd_13(_find_stmt(proc_s1, if_pat)) == _find_stmt(proc_s3, if_pat)
 
-    with pytest.raises(InvalidCursorError, match="cannot forward unknown procs"):
+    with pytest.raises(InvalidCursorError, match="cannot forward from unknown root"):
         fwd_23(x1_s1)
 
 
@@ -418,42 +411,15 @@ def test_double_insert_forwarding(golden):
     ],
 )
 def test_delete_forward_node(proc_bar, old, new):
-    for_j = proc_bar._TEST_find_stmt("for j in _: _").body()
+    for_j = _find_stmt(proc_bar, "for j in _: _").body()
     bar_new, fwd = for_j[2:4]._delete()
-    for_j_new = bar_new._TEST_find_stmt("for j in _: _").body()
+    for_j_new = _find_stmt(bar_new, "for j in _: _").body()
 
     if new is None:
         with pytest.raises(InvalidCursorError, match="node no longer exists"):
             fwd(for_j[old])
     else:
         assert fwd(for_j[old]) == for_j_new[new]
-
-
-def test_forward_lifetime(proc_bar):
-    """
-    Make sure that forwarding functions do not keep the cursors that created them
-    alive.
-    """
-
-    for_j = proc_bar._TEST_find_stmt("for j in _: _").body()[2:4]
-    for_j_weak = weakref.ref(for_j)
-
-    bar_new, fwd = for_j._delete()
-    bar_new_weak = weakref.ref(bar_new)
-
-    c = Cursor.create(bar_new).body()[0]
-    assert c._node() is not None
-
-    gc.collect()
-
-    assert for_j_weak() is not None
-    assert bar_new_weak() is not None
-
-    del for_j, bar_new
-    gc.collect()
-
-    assert for_j_weak() is None
-    assert bar_new_weak() is None
 
 
 @pytest.mark.parametrize(
@@ -468,39 +434,41 @@ def test_forward_lifetime(proc_bar):
     ],
 )
 def test_block_replace_forward_node(proc_bar, old, new):
-    for_j = proc_bar._TEST_find_stmt("for j in _: _").body()
+    for_j = _find_stmt(proc_bar, "for j in _: _").body()
     bar_new, fwd = for_j[1:4]._replace(
         [
-            LoopIR.Pass(None, for_j.parent()._node().srcinfo),
-            LoopIR.Pass(None, for_j.parent()._node().srcinfo),
+            LoopIR.Pass(None, for_j.parent()._node.srcinfo),
+            LoopIR.Pass(None, for_j.parent()._node.srcinfo),
         ]
     )
 
-    old_c = proc_bar._TEST_find_stmt(old)
+    old_c = _find_stmt(proc_bar, old)
 
     if new is None:
         with pytest.raises(InvalidCursorError, match="node no longer exists"):
             fwd(old_c)
     else:
-        assert fwd(old_c) == bar_new._TEST_find_stmt(new)
+        assert fwd(old_c) == match_pattern(bar_new, new)[0][0]
 
 
 def test_cursor_pretty_print_nodes(proc_bar, golden):
     output = []
 
-    root = Cursor.create(proc_bar)
+    ir = proc_bar._loopir_proc
+
+    root = Cursor.create(ir)
     output.append(_print_cursor(root))
 
-    c = proc_bar._TEST_find_stmt("for i in _: _")
+    c = _find_stmt(ir, "for i in _: _")
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("for j in _: _")
+    c = _find_stmt(ir, "for j in _: _")
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("x = 0.0")
+    c = _find_stmt(ir, "x = 0.0")
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("x = 2.0")
+    c = _find_stmt(ir, "x = 2.0")
     output.append(_print_cursor(c))
 
     assert "\n\n".join(output) == golden
@@ -509,22 +477,22 @@ def test_cursor_pretty_print_nodes(proc_bar, golden):
 def test_cursor_pretty_print_gaps(proc_bar, golden):
     output = []
 
-    c = proc_bar._TEST_find_stmt("x: f32").before()
+    c = _find_stmt(proc_bar, "x: f32").before()
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("for i in _: _").before()
+    c = _find_stmt(proc_bar, "for i in _: _").before()
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("for j in _: _").before()
+    c = _find_stmt(proc_bar, "for j in _: _").before()
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("x = 0.0").before()
+    c = _find_stmt(proc_bar, "x = 0.0").before()
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("x = 2.0").before()
+    c = _find_stmt(proc_bar, "x = 2.0").before()
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_stmt("x = 5.0").after()
+    c = _find_stmt(proc_bar, "x = 5.0").after()
     output.append(_print_cursor(c))
 
     assert "\n\n".join(output) == golden
@@ -533,26 +501,26 @@ def test_cursor_pretty_print_gaps(proc_bar, golden):
 def test_cursor_pretty_print_blocks(proc_bar, golden):
     output = []
 
-    c = proc_bar._TEST_find_stmt("for j in _: _").as_block()
+    c = _find_stmt(proc_bar, "for j in _: _").as_block()
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_cursors("x = 1.0; _; x = 3.0")[0]
+    c = _find_cursors(proc_bar, "x = 1.0; _; x = 3.0")[0]
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_cursors("x = 0.0; x = 1.0")[0]
+    c = _find_cursors(proc_bar, "x = 0.0; x = 1.0")[0]
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_cursors("x = 4.0; x = 5.0")[0]
+    c = _find_cursors(proc_bar, "x = 4.0; x = 5.0")[0]
     output.append(_print_cursor(c))
 
-    c = proc_bar._TEST_find_cursors("x = 0.0; _; x = 5.0")[0]
+    c = _find_cursors(proc_bar, "x = 0.0; _; x = 5.0")[0]
     output.append(_print_cursor(c))
 
     assert "\n\n".join(output) == golden
 
 
 def test_move_block(proc_bar, golden):
-    c = proc_bar._TEST_find_cursors("x = 1.0 ; x = 2.0")[0]
+    c = _find_cursors(proc_bar, "x = 1.0 ; x = 2.0")[0]
 
     # Movement within block
     p0, _ = c._move(c.before(2))
@@ -572,13 +540,13 @@ def test_move_block(proc_bar, golden):
     pu4, _ = c._move(c.parent().parent().after())
 
     # Movement downward (abbreviated)
-    c2 = proc_bar._TEST_find_cursors("x: _")[0]
+    c2 = _find_cursors(proc_bar, "x: _")[0]
     pd0, _ = c2._move(c.before(2))
     pd1, _ = c2._move(c.before())
     pd2, _ = c2._move(c2.after(2))
 
     # Move out a whole loop (needs to insert pass)
-    c3 = proc_bar._TEST_find_cursors("for j in _: _")[0]
+    c3 = _find_cursors(proc_bar, "for j in _: _")[0]
     pl0, _ = c3._move(c3.parent().after())
 
     all_tests = [p0, p1, p2, p3, p4, p5, pu0, pu1, pu2, pu3, pu4, pd0, pd1, pd2, pl0]
@@ -590,26 +558,26 @@ def _debug_print_forwarding(x, fwd):
     fx = fwd(x)
     print(x._path)
     print(_print_cursor(x))
-    print(x._root())
+    print(x._root)
     print("-----------")
     print(fx._path)
     print(_print_cursor(fx))
-    print(fx._root())
+    print(fx._root)
     print()
     print()
 
 
 def test_move_block_forwarding(proc_bar, golden):
-    c = proc_bar._TEST_find_cursors("x = 1.0 ; x = 2.0")[0]
+    c = _find_cursors(proc_bar, "x = 1.0 ; x = 2.0")[0]
 
     x_orig = []
     for i in range(6):
-        x_orig.append(proc_bar._TEST_find_stmt(f"x = {i}.0"))
+        x_orig.append(_find_stmt(proc_bar, f"x = {i}.0"))
 
     def _test_fwd(fwd):
         for x in x_orig:
             # _debug_print_forwarding(x, fwd)
-            assert str(fwd(x)._node()) == str(x._node())
+            assert str(fwd(x)._node) == str(x._node)
 
     # Movement within block
     _, fwd0 = c._move(c.before(2))
@@ -638,7 +606,7 @@ def test_move_block_forwarding(proc_bar, golden):
     _test_fwd(fwd10)
 
     # Movement downward (abbreviated)
-    c2 = proc_bar._TEST_find_cursors("x: _")[0]
+    c2 = _find_cursors(proc_bar, "x: _")[0]
     _, fwd11 = c2._move(c.before(2))
     _test_fwd(fwd11)
     _, fwd12 = c2._move(c.before())
@@ -647,7 +615,7 @@ def test_move_block_forwarding(proc_bar, golden):
     _test_fwd(fwd13)
 
     # Move out a whole loop
-    c3 = proc_bar._TEST_find_cursors("for j in _: _")[0]
+    c3 = _find_cursors(proc_bar, "for j in _: _")[0]
     _, fwd14 = c3._move(c3.parent().after())
     _test_fwd(fwd14)
 
@@ -663,7 +631,7 @@ def test_wrap_block(proc_bar, golden):
     procs = []
     for i in range(0, 6):
         for j in range(i + 1, 6):
-            c = proc_bar._TEST_find_cursors(f"x = {i}.0 ; _ ; x = {j}.0")[0]
+            c = _find_cursors(proc_bar, f"x = {i}.0 ; _ ; x = {j}.0")[0]
             p, _ = c._wrap(wrapper, "body")
             procs.append(p)
 
@@ -673,12 +641,12 @@ def test_wrap_block(proc_bar, golden):
 def test_wrap_block_forward(proc_bar):
     x_orig = []
     for i in range(6):
-        x_orig.append(proc_bar._TEST_find_stmt(f"x = {i}.0"))
+        x_orig.append(_find_stmt(proc_bar, f"x = {i}.0"))
 
     def _test_fwd(fwd):
         for x in x_orig:
             # _debug_print_forwarding(x, fwd)
-            assert str(fwd(x)._node()) == str(x._node())
+            assert str(fwd(x)._node) == str(x._node)
 
     def wrapper(orelse):
         src = orelse[0].srcinfo
@@ -687,6 +655,6 @@ def test_wrap_block_forward(proc_bar):
 
     for i in range(0, 6):
         for j in range(i + 1, 6):
-            c = proc_bar._TEST_find_cursors(f"x = {i}.0 ; _ ; x = {j}.0")[0]
+            c = _find_cursors(proc_bar, f"x = {i}.0 ; _ ; x = {j}.0")[0]
             _, fwd = c._wrap(wrapper, "orelse")
             _test_fwd(fwd)


### PR DESCRIPTION
I'm just going to merge this into the other branch, but because it's a somewhat substantial change, I wanted to give it its own discussion / PR number.

The internal cursor editing functions used to return a new _Procedure_ (api-level) and a forwarding function. Now they return a new _LoopIR.proc_ (internal) and a forwarding function.

This change was necessary to support `delete_config`, which requires also changing the `_mod_config` property on the `Procedure`, in addition to the provenance.

Now that the internal cursors do not reference API Procedures (well, almost... that's the end goal), the weak-reference optimization became less profitable, so I removed it for the sake of simplicity. It used to be that leaking a single cursor could keep an entire provenance chain alive. Now it can only keep one tree alive.