### PR TITLE
rewrote reuse_buffer with internal cursors

### DIFF
--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -1317,9 +1317,8 @@ def reuse_buffer(proc, buf_cursor, replace_cursor):
     """
     buf_s = buf_cursor._impl
     rep_s = replace_cursor._impl
-    proc_c = ic.Cursor.create(proc)
-
-    return scheduling.DoDataReuse(proc_c, buf_s, rep_s).result()
+    ir, _fwd = scheduling.DoDataReuse(buf_s, rep_s)
+    return Procedure(ir, _provenance_eq_Procedure=proc)
 
 
 @sched_op([WindowStmtCursorA])

--- a/tests/golden/test_schedules/test_reuse_buffer2.txt
+++ b/tests/golden/test_schedules/test_reuse_buffer2.txt
@@ -1,0 +1,3 @@
+def foo():
+    bb: f32 @ DRAM
+    bar(bb)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -731,6 +731,21 @@ def test_reuse_buffer(golden):
     assert str(foo) == golden
 
 
+def test_reuse_buffer2(golden):
+    @proc
+    def bar(a: f32):
+        pass
+
+    @proc
+    def foo():
+        bb: f32
+        c: f32
+        bar(c)
+
+    foo = reuse_buffer(foo, "bb:_", "c:_")
+    assert str(foo) == golden
+
+
 def test_reuse_buffer_loop_fail():
     @proc
     def foo(a: f32 @ DRAM, b: f32 @ DRAM):


### PR DESCRIPTION
In addition, made some changes to move cursor-specific code into `_replace_pats` functions so that I don't have to simplify the `mk_read` and `mk_write` replacement functions I have to write each time. 