### PR TITLE
Fix divide loop

### DIFF
--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -626,7 +626,7 @@ class DoSplit(Cursor_Rewrite):
 
     def map_e(self, e):
         if isinstance(e, LoopIR.Read):
-            if e.is_indexable():
+            if e.type.is_indexable():
                 # This is a split variable, substitute it!
                 print(repr(e.name), repr(self.split_var))
                 if e.name is self.split_var:
@@ -640,7 +640,7 @@ class DoSplit(Cursor_Rewrite):
 
     def map_eff_e(self, e):
         if isinstance(e, E.Var):
-            if e.type is T.index:
+            if e.type.is_indexable():
                 # This is a split variable, substitute it!
                 if e.name is self.split_var:
                     if self._in_cut_tail:

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -626,8 +626,9 @@ class DoSplit(Cursor_Rewrite):
 
     def map_e(self, e):
         if isinstance(e, LoopIR.Read):
-            if e.type is T.index:
+            if e.is_indexable():
                 # This is a split variable, substitute it!
+                print(repr(e.name), repr(self.split_var))
                 if e.name is self.split_var:
                     if self._in_cut_tail:
                         return self.cut_tail_sub(e.srcinfo)


### PR DESCRIPTION
`T.index` doesn't include size and integers. This bug appeared as a weird error in SYRK.