### PR TITLE
Undo changes to internal cursors for fnargs

### DIFF
--- a/src/exo/API.py
+++ b/src/exo/API.py
@@ -253,7 +253,7 @@ class Procedure(ProcedureBase):
         return self._loopir_proc.instr
 
     def args(self):
-        args = self._root()._args()
+        args = self._root()._child_block("args")
         return C.lift_cursor(args, self)
 
     def body(self):

--- a/src/exo/internal_cursors.py
+++ b/src/exo/internal_cursors.py
@@ -196,14 +196,6 @@ class Cursor(ABC):
 
 
 @dataclass
-class Args(Cursor):
-    _anchor: Node
-
-    def parent(self) -> Node:
-        return self._anchor
-
-
-@dataclass
 class Block(Cursor):
     _anchor: Node
     _attr: str  # must be 'body' or 'orelse'
@@ -570,9 +562,6 @@ class Node(Cursor):
     # ------------------------------------------------------------------------ #
     # Navigation (children)
     # ------------------------------------------------------------------------ #
-
-    def _args(self):
-        return Args(self._root, self)
 
     def _child_node(self, attr, i=None) -> Node:
         _node = getattr(self._node, attr)


### PR DESCRIPTION
In #399, the internal cursors were modified to access the function arguments of a proc. This should not have been done. The internal cursors are meant to be as ignorant of LoopIR as possible. This PR moves these concepts to the API layer.