### PR TITLE
Try inlining constant strides at codegen time

### DIFF
--- a/src/exo/LoopIR_compiler.py
+++ b/src/exo/LoopIR_compiler.py
@@ -499,7 +499,9 @@ class Compiler:
                 and isinstance(pred.lhs, LoopIR.StrideExpr)
                 and isinstance(pred.rhs, LoopIR.Const)
             ):
-                self._known_strides[(pred.lhs.name, pred.lhs.dim)] = str(pred.rhs.val)
+                nm = self.env[pred.lhs.name]
+                self._known_strides[(nm, pred.lhs.dim)] = str(pred.rhs.val)
+                self.add_line(f"// assert {pred}")
             else:
                 # Default to just informing the compiler about the constraint
                 # on a best-effort basis

--- a/src/exo/LoopIR_compiler.py
+++ b/src/exo/LoopIR_compiler.py
@@ -452,6 +452,7 @@ class Compiler:
         self._scalar_refs = set()
         self._needed_helpers = set()
         self.window_defns = set()
+        self._known_strides = {}
 
         assert self.proc.name is not None, "expected names for compilation"
         name = self.proc.name
@@ -488,7 +489,20 @@ class Compiler:
                 typ_comments.append(comment_str)
 
         for pred in proc.preds:
-            if not isinstance(pred, LoopIR.Const):
+            if isinstance(pred, LoopIR.Const):
+                # TODO: filter these out earlier?
+                continue
+
+            if (
+                isinstance(pred, LoopIR.BinOp)
+                and pred.op == "=="
+                and isinstance(pred.lhs, LoopIR.StrideExpr)
+                and isinstance(pred.rhs, LoopIR.Const)
+            ):
+                self._known_strides[(pred.lhs.name, pred.lhs.dim)] = str(pred.rhs.val)
+            else:
+                # Default to just informing the compiler about the constraint
+                # on a best-effort basis
                 self.add_line(f"EXO_ASSUME({self.comp_e(pred)});")
 
         if not self.static_memory_check(self.proc):
@@ -629,10 +643,16 @@ class Compiler:
         strides = list(reversed(strides))
         return strides
 
+    def get_stride(self, name, i):
+        if stride := self._known_strides.get((name, i)):
+            return stride
+        else:
+            return f"{name}.strides[{i}]"
+
     # works for any tensor or window type
     def get_strides(self, name, typ, prec=100):
         if typ.is_win():
-            return [f"{name}.strides[{i}]" for i in range(len(typ.shape()))]
+            return [self.get_stride(name, i) for i in range(len(typ.shape()))]
         else:
             return self.tensor_strides(typ.shape(), prec)
 

--- a/tests/golden/test_apps/test_neon_sgemm.txt
+++ b/tests/golden/test_apps/test_neon_sgemm.txt
@@ -93,23 +93,23 @@ neon_broadcast_4xf32(dst,src)
 // )
 static void neon_microkernel( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 float32x4_t C_reg[4][4];
 for (int i = 0; i < 4; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = vld1q_f32(&C.data[(i) * (C.strides[0]) + (4 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = vld1q_f32(&C.data[(i) * (C.strides[0]) + (4 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   float32x4_t A_vec;
   for (int i = 0; i < 4; i++) {
-    A_vec = vld1q_dup_f32(&A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = vld1q_dup_f32(&A.data[(i) * (A.strides[0]) + (k) * (1)]);
   }
   float32x4_t B_vec;
   for (int jo = 0; jo < 4; jo++) {
-    B_vec = vld1q_f32(&B.data[(k) * (B.strides[0]) + (4 * jo) * (B.strides[1])]);
+    B_vec = vld1q_f32(&B.data[(k) * (B.strides[0]) + (4 * jo) * (1)]);
   }
   for (int i = 0; i < 4; i++) {
     for (int jo = 0; jo < 4; jo++) {
@@ -119,7 +119,7 @@ for (int k = 0; k < K; k++) {
 }
 for (int i = 0; i < 4; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    vst1q_f32(&C.data[(i) * (C.strides[0]) + (4 * jo) * (C.strides[1])], C_reg[i][jo]);
+    vst1q_f32(&C.data[(i) * (C.strides[0]) + (4 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }
@@ -151,9 +151,9 @@ void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, cons
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(1 == 1);
-EXO_ASSUME(1 == 1);
-EXO_ASSUME(1 == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 float *Atile = malloc(64 * 64 * sizeof(*Atile));
 float *Btile = malloc(64 * 64 * sizeof(*Btile));
 for (int ko = 0; ko < ((K) / (64)); ko++) {

--- a/tests/golden/test_apps/test_x86_sgemm.txt
+++ b/tests/golden/test_apps/test_x86_sgemm.txt
@@ -161,29 +161,29 @@ static void sgemm_kernel_avx512_6x4( void *ctxt, int_fast32_t K, struct exo_win_
 static void bottom_panel_kernel_scheduled( void *ctxt, int_fast32_t M, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 EXO_ASSUME(M < 6);
 if (M == 1) {
-  sgemm_kernel_avx512_1x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+  sgemm_kernel_avx512_1x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (1)], { C.strides[0], 1 } });
 } else {
   if (M == 2) {
-    sgemm_kernel_avx512_2x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    sgemm_kernel_avx512_2x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (1)], { C.strides[0], 1 } });
   } else {
     if (M == 3) {
-      sgemm_kernel_avx512_3x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+      sgemm_kernel_avx512_3x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (1)], { C.strides[0], 1 } });
     } else {
       if (M == 4) {
-        sgemm_kernel_avx512_4x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+        sgemm_kernel_avx512_4x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (1)], { C.strides[0], 1 } });
       } else {
         if (M == 5) {
-          sgemm_kernel_avx512_5x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+          sgemm_kernel_avx512_5x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(0) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (0) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(0) * (C.strides[0]) + (0) * (1)], { C.strides[0], 1 } });
         } else {
           for (int k = 0; k < K; k++) {
             for (int i = 0; i < M; i++) {
               for (int j = 0; j < 64; j++) {
-                C.data[(i) * (C.strides[0]) + (j) * (C.strides[1])] += A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])] * B.data[(k) * (B.strides[0]) + (j) * (B.strides[1])];
+                C.data[(i) * (C.strides[0]) + (j) * (1)] += A.data[(i) * (A.strides[0]) + (k) * (1)] * B.data[(k) * (B.strides[0]) + (j) * (1)];
               }
             }
           }
@@ -244,27 +244,27 @@ _mm512_storeu_ps(&{dst_data}, {src_data});
 static void right_panel_kernel_scheduled( void *ctxt, int_fast32_t N, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 EXO_ASSUME(((N) / (16)) < 4);
 if (((N) / (16)) == 0) {
   __m512 C_reg[6][1];
   __m512 C_reg_1[6];
   for (int i = 0; i < 6; i++) {
-    C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N)) - 1), &C.data[(i) * (C.strides[0]) + (0) * (C.strides[1])]);
+    C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N)) - 1), &C.data[(i) * (C.strides[0]) + (0) * (1)]);
   }
   for (int k = 0; k < K; k++) {
     for (int i = 0; i < 6; i++) {
       __m512 A_reg2;
-      A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+      A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
       __m512 B_reg2;
-      B_reg2 = _mm512_maskz_loadu_ps(((1 << (N)) - 1), &B.data[(k) * (B.strides[0]) + (0) * (B.strides[1])]);
+      B_reg2 = _mm512_maskz_loadu_ps(((1 << (N)) - 1), &B.data[(k) * (B.strides[0]) + (0) * (1)]);
       C_reg_1[i] = _mm512_mask_fmadd_ps(A_reg2, ((1 << (N)) - 1), B_reg2, C_reg_1[i]);
     }
   }
   for (int i = 0; i < 6; i++) {
-    _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (0) * (C.strides[1])], ((1 << (N)) - 1), C_reg_1[i]);
+    _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (0) * (1)], ((1 << (N)) - 1), C_reg_1[i]);
   }
 } else {
   if (((N) / (16)) == 1) {
@@ -272,31 +272,31 @@ if (((N) / (16)) == 0) {
     __m512 C_reg_1[6];
     for (int i = 0; i < 6; i++) {
       for (int jo = 0; jo < 1; jo++) {
-        C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+        C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
       }
-      C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (16) * (C.strides[1])]);
+      C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (16) * (1)]);
     }
     for (int k = 0; k < K; k++) {
       for (int i = 0; i < 6; i++) {
         for (int jo = 0; jo < 1; jo++) {
           __m512 A_reg;
-          A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+          A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
           __m512 B_reg;
-          B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+          B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
           C_reg[i][jo] = _mm512_fmadd_ps(A_reg, B_reg, C_reg[i][jo]);
         }
         __m512 A_reg2;
-        A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+        A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
         __m512 B_reg2;
-        B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (16) * (B.strides[1])]);
+        B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (16) * (1)]);
         C_reg_1[i] = _mm512_mask_fmadd_ps(A_reg2, ((1 << (N % 16)) - 1), B_reg2, C_reg_1[i]);
       }
     }
     for (int i = 0; i < 6; i++) {
       for (int jo = 0; jo < 1; jo++) {
-        _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+        _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
       }
-      _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (16) * (C.strides[1])], ((1 << (N % 16)) - 1), C_reg_1[i]);
+      _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (16) * (1)], ((1 << (N % 16)) - 1), C_reg_1[i]);
     }
   } else {
     if (((N) / (16)) == 2) {
@@ -304,31 +304,31 @@ if (((N) / (16)) == 0) {
       __m512 C_reg_1[6];
       for (int i = 0; i < 6; i++) {
         for (int jo = 0; jo < 2; jo++) {
-          C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+          C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
         }
-        C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (32) * (C.strides[1])]);
+        C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (32) * (1)]);
       }
       for (int k = 0; k < K; k++) {
         for (int i = 0; i < 6; i++) {
           for (int jo = 0; jo < 2; jo++) {
             __m512 A_reg;
-            A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+            A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
             __m512 B_reg;
-            B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+            B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
             C_reg[i][jo] = _mm512_fmadd_ps(A_reg, B_reg, C_reg[i][jo]);
           }
           __m512 A_reg2;
-          A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+          A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
           __m512 B_reg2;
-          B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (32) * (B.strides[1])]);
+          B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (32) * (1)]);
           C_reg_1[i] = _mm512_mask_fmadd_ps(A_reg2, ((1 << (N % 16)) - 1), B_reg2, C_reg_1[i]);
         }
       }
       for (int i = 0; i < 6; i++) {
         for (int jo = 0; jo < 2; jo++) {
-          _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+          _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
         }
-        _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (32) * (C.strides[1])], ((1 << (N % 16)) - 1), C_reg_1[i]);
+        _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (32) * (1)], ((1 << (N % 16)) - 1), C_reg_1[i]);
       }
     } else {
       if (((N) / (16)) == 3) {
@@ -336,62 +336,62 @@ if (((N) / (16)) == 0) {
         __m512 C_reg_1[6];
         for (int i = 0; i < 6; i++) {
           for (int jo = 0; jo < 3; jo++) {
-            C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+            C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
           }
-          C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (48) * (C.strides[1])]);
+          C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (48) * (1)]);
         }
         for (int k = 0; k < K; k++) {
           for (int i = 0; i < 6; i++) {
             for (int jo = 0; jo < 3; jo++) {
               __m512 A_reg;
-              A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+              A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
               __m512 B_reg;
-              B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+              B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
               C_reg[i][jo] = _mm512_fmadd_ps(A_reg, B_reg, C_reg[i][jo]);
             }
             __m512 A_reg2;
-            A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+            A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
             __m512 B_reg2;
-            B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (48) * (B.strides[1])]);
+            B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (48) * (1)]);
             C_reg_1[i] = _mm512_mask_fmadd_ps(A_reg2, ((1 << (N % 16)) - 1), B_reg2, C_reg_1[i]);
           }
         }
         for (int i = 0; i < 6; i++) {
           for (int jo = 0; jo < 3; jo++) {
-            _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+            _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
           }
-          _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (48) * (C.strides[1])], ((1 << (N % 16)) - 1), C_reg_1[i]);
+          _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (48) * (1)], ((1 << (N % 16)) - 1), C_reg_1[i]);
         }
       } else {
         __m512 C_reg[6][(((N) / (16)) + 1)];
         __m512 C_reg_1[6];
         for (int i = 0; i < 6; i++) {
           for (int jo = 0; jo < ((N) / (16)); jo++) {
-            C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+            C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
           }
-          C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (16 * ((N) / (16))) * (C.strides[1])]);
+          C_reg_1[i] = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &C.data[(i) * (C.strides[0]) + (16 * ((N) / (16))) * (1)]);
         }
         for (int k = 0; k < K; k++) {
           for (int i = 0; i < 6; i++) {
             for (int jo = 0; jo < ((N) / (16)); jo++) {
               __m512 A_reg;
-              A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+              A_reg = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
               __m512 B_reg;
-              B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+              B_reg = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
               C_reg[i][jo] = _mm512_fmadd_ps(A_reg, B_reg, C_reg[i][jo]);
             }
             __m512 A_reg2;
-            A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+            A_reg2 = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
             __m512 B_reg2;
-            B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (16 * ((N) / (16))) * (B.strides[1])]);
+            B_reg2 = _mm512_maskz_loadu_ps(((1 << (N % 16)) - 1), &B.data[(k) * (B.strides[0]) + (16 * ((N) / (16))) * (1)]);
             C_reg_1[i] = _mm512_mask_fmadd_ps(A_reg2, ((1 << (N % 16)) - 1), B_reg2, C_reg_1[i]);
           }
         }
         for (int i = 0; i < 6; i++) {
           for (int jo = 0; jo < ((N) / (16)); jo++) {
-            _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+            _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
           }
-          _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * ((N) / (16))) * (C.strides[1])], ((1 << (N % 16)) - 1), C_reg_1[i]);
+          _mm512_mask_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * ((N) / (16))) * (1)], ((1 << (N % 16)) - 1), C_reg_1[i]);
         }
       }
     }
@@ -411,28 +411,28 @@ static void sgemm_above_kernel( void *ctxt, int_fast32_t M, int_fast32_t N, int_
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 for (int io = 0; io < ((M) / (6)); io++) {
   for (int jo = 0; jo < ((N) / (64)); jo++) {
-    sgemm_kernel_avx512_6x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(6 * io) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * jo) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(6 * io) * (C.strides[0]) + (64 * jo) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    sgemm_kernel_avx512_6x4(ctxt,K,(struct exo_win_2f32c){ &A.data[(6 * io) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * jo) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(6 * io) * (C.strides[0]) + (64 * jo) * (1)], { C.strides[0], 1 } });
   }
 }
 if (N % 64 > 0) {
   for (int io = 0; io < ((M) / (6)); io++) {
-    right_panel_kernel_scheduled(ctxt,N % 64,K,(struct exo_win_2f32c){ &A.data[(6 * io) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * ((N) / (64))) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(6 * io) * (C.strides[0]) + (64 * ((N) / (64))) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    right_panel_kernel_scheduled(ctxt,N % 64,K,(struct exo_win_2f32c){ &A.data[(6 * io) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * ((N) / (64))) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(6 * io) * (C.strides[0]) + (64 * ((N) / (64))) * (1)], { C.strides[0], 1 } });
   }
 }
 if (M % 6 > 0) {
   for (int jo = 0; jo < ((N) / (64)); jo++) {
-    bottom_panel_kernel_scheduled(ctxt,M % 6,K,(struct exo_win_2f32c){ &A.data[(6 * ((M) / (6))) * (A.strides[0]) + (0) * (A.strides[1])], { A.strides[0], A.strides[1] } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * jo) * (B.strides[1])], { B.strides[0], B.strides[1] } },(struct exo_win_2f32){ &C.data[(6 * ((M) / (6))) * (C.strides[0]) + (64 * jo) * (C.strides[1])], { C.strides[0], C.strides[1] } });
+    bottom_panel_kernel_scheduled(ctxt,M % 6,K,(struct exo_win_2f32c){ &A.data[(6 * ((M) / (6))) * (A.strides[0]) + (0) * (1)], { A.strides[0], 1 } },(struct exo_win_2f32c){ &B.data[(0) * (B.strides[0]) + (64 * jo) * (1)], { B.strides[0], 1 } },(struct exo_win_2f32){ &C.data[(6 * ((M) / (6))) * (C.strides[0]) + (64 * jo) * (1)], { C.strides[0], 1 } });
   }
   if (N % 64 > 0) {
     for (int k = 0; k < K; k++) {
       for (int ii = 0; ii < M % 6; ii++) {
         for (int ji = 0; ji < N % 64; ji++) {
-          C.data[(ii + ((M) / (6)) * 6) * (C.strides[0]) + (ji + ((N) / (64)) * 64) * (C.strides[1])] += A.data[(ii + ((M) / (6)) * 6) * (A.strides[0]) + (k) * (A.strides[1])] * B.data[(k) * (B.strides[0]) + (ji + ((N) / (64)) * 64) * (B.strides[1])];
+          C.data[(ii + ((M) / (6)) * 6) * (C.strides[0]) + (ji + ((N) / (64)) * 64) * (1)] += A.data[(ii + ((M) / (6)) * 6) * (A.strides[0]) + (k) * (1)] * B.data[(k) * (B.strides[0]) + (ji + ((N) / (64)) * 64) * (1)];
         }
       }
     }
@@ -452,9 +452,9 @@ void sgemm_exo( void *ctxt, int_fast32_t M, int_fast32_t N, int_fast32_t K, cons
 EXO_ASSUME(M >= 1);
 EXO_ASSUME(N >= 1);
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(1 == 1);
-EXO_ASSUME(1 == 1);
-EXO_ASSUME(1 == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 static float A1_cache[264 * 512];
 static float B1_cache[512 * 64];
 for (int ko = 0; ko < ((K) / (512)); ko++) {
@@ -575,29 +575,29 @@ if (K % 512 > 0) {
 // )
 static void sgemm_kernel_avx512_1x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 __m512 C_reg[1][4];
 for (int i = 0; i < 1; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   for (int i = 0; i < 1; i++) {
     __m512 A_vec;
-    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
     for (int jo = 0; jo < 4; jo++) {
       __m512 B_vec;
-      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
       C_reg[i][jo] = _mm512_fmadd_ps(A_vec, B_vec, C_reg[i][jo]);
     }
   }
 }
 for (int i = 0; i < 1; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }
@@ -610,29 +610,29 @@ for (int i = 0; i < 1; i++) {
 // )
 static void sgemm_kernel_avx512_2x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 __m512 C_reg[2][4];
 for (int i = 0; i < 2; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   for (int i = 0; i < 2; i++) {
     __m512 A_vec;
-    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
     for (int jo = 0; jo < 4; jo++) {
       __m512 B_vec;
-      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
       C_reg[i][jo] = _mm512_fmadd_ps(A_vec, B_vec, C_reg[i][jo]);
     }
   }
 }
 for (int i = 0; i < 2; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }
@@ -645,29 +645,29 @@ for (int i = 0; i < 2; i++) {
 // )
 static void sgemm_kernel_avx512_3x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 __m512 C_reg[3][4];
 for (int i = 0; i < 3; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   for (int i = 0; i < 3; i++) {
     __m512 A_vec;
-    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
     for (int jo = 0; jo < 4; jo++) {
       __m512 B_vec;
-      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
       C_reg[i][jo] = _mm512_fmadd_ps(A_vec, B_vec, C_reg[i][jo]);
     }
   }
 }
 for (int i = 0; i < 3; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }
@@ -680,29 +680,29 @@ for (int i = 0; i < 3; i++) {
 // )
 static void sgemm_kernel_avx512_4x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 __m512 C_reg[4][4];
 for (int i = 0; i < 4; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   for (int i = 0; i < 4; i++) {
     __m512 A_vec;
-    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
     for (int jo = 0; jo < 4; jo++) {
       __m512 B_vec;
-      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
       C_reg[i][jo] = _mm512_fmadd_ps(A_vec, B_vec, C_reg[i][jo]);
     }
   }
 }
 for (int i = 0; i < 4; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }
@@ -715,29 +715,29 @@ for (int i = 0; i < 4; i++) {
 // )
 static void sgemm_kernel_avx512_5x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 __m512 C_reg[5][4];
 for (int i = 0; i < 5; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   for (int i = 0; i < 5; i++) {
     __m512 A_vec;
-    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
     for (int jo = 0; jo < 4; jo++) {
       __m512 B_vec;
-      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
       C_reg[i][jo] = _mm512_fmadd_ps(A_vec, B_vec, C_reg[i][jo]);
     }
   }
 }
 for (int i = 0; i < 5; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }
@@ -750,29 +750,29 @@ for (int i = 0; i < 5; i++) {
 // )
 static void sgemm_kernel_avx512_6x4( void *ctxt, int_fast32_t K, struct exo_win_2f32c A, struct exo_win_2f32c B, struct exo_win_2f32 C ) {
 EXO_ASSUME(K >= 1);
-EXO_ASSUME(A.strides[1] == 1);
-EXO_ASSUME(B.strides[1] == 1);
-EXO_ASSUME(C.strides[1] == 1);
+// assert stride(A, 1) == 1
+// assert stride(B, 1) == 1
+// assert stride(C, 1) == 1
 __m512 C_reg[6][4];
 for (int i = 0; i < 6; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])]);
+    C_reg[i][jo] = _mm512_loadu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)]);
   }
 }
 for (int k = 0; k < K; k++) {
   for (int i = 0; i < 6; i++) {
     __m512 A_vec;
-    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (A.strides[1])]);
+    A_vec = _mm512_set1_ps(A.data[(i) * (A.strides[0]) + (k) * (1)]);
     for (int jo = 0; jo < 4; jo++) {
       __m512 B_vec;
-      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (B.strides[1])]);
+      B_vec = _mm512_loadu_ps(&B.data[(k) * (B.strides[0]) + (16 * jo) * (1)]);
       C_reg[i][jo] = _mm512_fmadd_ps(A_vec, B_vec, C_reg[i][jo]);
     }
   }
 }
 for (int i = 0; i < 6; i++) {
   for (int jo = 0; jo < 4; jo++) {
-    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (C.strides[1])], C_reg[i][jo]);
+    _mm512_storeu_ps(&C.data[(i) * (C.strides[0]) + (16 * jo) * (1)], C_reg[i][jo]);
   }
 }
 }

--- a/tests/golden/test_window/test_stride_assert.txt
+++ b/tests/golden/test_window/test_stride_assert.txt
@@ -54,12 +54,12 @@ void stride_assert( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2
 void stride_assert( void *ctxt, int_fast32_t n, int_fast32_t m, struct exo_win_2i8c src, struct exo_win_2i8 dst ) {
 EXO_ASSUME(n <= 16);
 EXO_ASSUME(m <= 16);
-EXO_ASSUME(src.strides[1] == 1);
-EXO_ASSUME(dst.strides[0] == 16);
-EXO_ASSUME(dst.strides[1] == 1);
+// assert stride(src, 1) == 1
+// assert stride(dst, 0) == 16
+// assert stride(dst, 1) == 1
 for (int i = 0; i < n; i++) {
   for (int j = 0; j < m; j++) {
-    dst.data[(i) * (dst.strides[0]) + (j) * (dst.strides[1])] = src.data[(i) * (src.strides[0]) + (j) * (src.strides[1])];
+    dst.data[(i) * (16) + (j) * (1)] = src.data[(i) * (src.strides[0]) + (j) * (1)];
   }
 }
 }


### PR DESCRIPTION
Expressions like `assert stride(buffer, 1) == 1` were previously translated to `EXO_ASSUME` macros, but this isn't always respected by compilers. We now inline such expressions manually.