### PR TITLE
Propagate InferEffects to subprocedure calls

### DIFF
--- a/src/exo/API.py
+++ b/src/exo/API.py
@@ -238,9 +238,11 @@ class Procedure(ProcedureBase):
         return self._loopir_proc.name
 
     def show_effects(self):
+        self._loopir_proc = InferEffects(self._loopir_proc).result()
         return str(self._loopir_proc.eff)
 
     def show_effect(self, stmt_pattern):
+        self._loopir_proc = InferEffects(self._loopir_proc).result()
         if match := match_pattern(
             self._root(), stmt_pattern, call_depth=1, default_match_no=0
         ):

--- a/src/exo/effectcheck.py
+++ b/src/exo/effectcheck.py
@@ -241,7 +241,7 @@ class InferEffects:
                     if isinstance(arg.type, T.Window):
                         eff = self.translate_eff(eff, sig.name, arg.type)
 
-            return LoopIR.Call(subproc, stmt.args, eff, stmt.srcinfo)
+            return LoopIR.Call(stmt.f, stmt.args, eff, stmt.srcinfo)
 
         elif isinstance(stmt, LoopIR.Pass):
             return LoopIR.Pass(eff_null(stmt.srcinfo), stmt.srcinfo)

--- a/src/exo/effectcheck.py
+++ b/src/exo/effectcheck.py
@@ -211,8 +211,9 @@ class InferEffects:
             assert stmt.f.eff is not None
             # build up a substitution dictionary....
             # sig is a LoopIR.fnarg, arg is a LoopIR.expr
+            subproc = InferEffects(stmt.f).result()
             subst = {}
-            for sig, arg in zip(stmt.f.args, stmt.args):
+            for sig, arg in zip(subproc.args, stmt.args):
                 if sig.type.is_numeric():
                     if isinstance(arg.type, T.Window):
                         pass  # handle below
@@ -231,16 +232,16 @@ class InferEffects:
                 else:
                     assert False, "bad case"
 
-            eff = stmt.f.eff
+            eff = subproc.eff
             eff = eff.subst(subst)
 
             # translate effects occuring on windowed arguments
-            for sig, arg in zip(stmt.f.args, stmt.args):
+            for sig, arg in zip(subproc.args, stmt.args):
                 if sig.type.is_numeric():
                     if isinstance(arg.type, T.Window):
                         eff = self.translate_eff(eff, sig.name, arg.type)
 
-            return LoopIR.Call(stmt.f, stmt.args, eff, stmt.srcinfo)
+            return LoopIR.Call(subproc, stmt.args, eff, stmt.srcinfo)
 
         elif isinstance(stmt, LoopIR.Pass):
             return LoopIR.Pass(eff_null(stmt.srcinfo), stmt.srcinfo)

--- a/tests/golden/test_effects/test_infereffects.txt
+++ b/tests/golden/test_effects/test_infereffects.txt
@@ -1,0 +1,3 @@
+Writes:
+    { A : (i,j) for (i,j) in Z if
+    0 <= i and i < 10 and (0 <= j and j < 20) }

--- a/tests/golden/test_effects/test_infereffects2.txt
+++ b/tests/golden/test_effects/test_infereffects2.txt
@@ -1,0 +1,3 @@
+Writes:
+    { A : (i,j) for (i,j) in Z if
+    0 <= i and i < 10 and (0 <= j and j < 20) }

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -544,6 +544,22 @@ def test_stride_assert11(golden):
     assert bar.show_effects() == golden
 
 
+def test_infereffects(golden):
+    @proc
+    def foo(n: size, m: size, A: f32[n, m]):
+        for i in seq(0, n):
+            for j in seq(0, m):
+                A[i, j] = 0.0
+
+    foo = foo.partial_eval(10, 20)
+
+    @proc
+    def bar(A: f32[10, 20]):
+        foo(A)
+
+    assert bar.show_effects() == golden
+
+
 # are we testing a case of an else branch?
 
 # what if effset.pred is None?

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -560,6 +560,17 @@ def test_infereffects(golden):
     assert bar.show_effects() == golden
 
 
+def test_infereffects2(golden):
+    @proc
+    def foo(n: size, m: size, A: f32[n, m]):
+        for i in seq(0, n):
+            for j in seq(0, m):
+                A[i, j] = 0.0
+
+    foo = foo.partial_eval(10, 20)
+    assert foo.show_effects() == golden
+
+
 # are we testing a case of an else branch?
 
 # what if effset.pred is None?


### PR DESCRIPTION
Fixes a bug where the changes in `foo`'s effects were not propagated after partial eval, resulting in the effectcheck error in `bar`.