### PR TITLE
Fixed issue with forwarding when procs are equivalent. 

### DIFF
--- a/src/exo/API.py
+++ b/src/exo/API.py
@@ -201,7 +201,7 @@ class Procedure(ProcedureBase):
     def forward(self, cur: C.Cursor):
         p = self
         fwds = []
-        while p is not None and p != cur.proc():
+        while p is not None and p is not cur.proc():
             fwds.append(p._forward)
             p = p._provenance_eq_Procedure
 

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -288,7 +288,7 @@ def test_forwarding_for_procs_with_identical_code():
     foo = stage_mem(foo, loop_cursor, "x[0:8]", "x_tmp")
     alloc_cursor = foo.find("x : _")
     foo = set_memory(foo, alloc_cursor, AVX2)
-    foo = set_precision(foo, alloc_cursor, "f32")
+    foo = expand_dim(foo, alloc_cursor, "1", "0")
     foo.forward(loop_cursor)
 
 

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -284,10 +284,9 @@ def test_forwarding_for_procs_with_identical_code():
         for i in seq(0, 8):
             x[i] += 1.0
 
-    loop_cursor = foo.find_loop("i")
-    foo = stage_mem(foo, loop_cursor, "x[0:8]", "x_tmp")
     alloc_cursor = foo.find("x : _")
     foo = set_memory(foo, alloc_cursor, AVX2)
+    loop_cursor = foo.find_loop("i")
     foo = expand_dim(foo, alloc_cursor, "1", "0")
     foo.forward(loop_cursor)
 


### PR DESCRIPTION
The bug is a simple matter of changing `!=`! to `is not`. This matters because the former checks object equivalence and the latter checks memory equivalence. This matter for correctly defining forwarding functions. 

In the test case I added, here are relevant points which lead to an error in the original implementation. Let `C0` be the initial IR and `Ci` be the proc after the `i`-th scheduling operation. 
- `set_memory` and `expand_dim` take the same cursor as input. 
- The input cursor we pass to `expand_dim` is anchored to `C0` because `C0` and `C1` have the same IR, so we don't forward the input cursor in the `expand_dim` call. 
- In most scheduling operations, we derive the IR from the input cursor, so `expand_dim`'s forwarding function anchors to `C0`, when it really should be anchored to `C1`. This later manifests as an error in forwarding cursors. 