### PR TITLE
Fix unification bug when unifying conditions

### DIFF
--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -280,6 +280,7 @@ module CIR {
             | Stride  ( sym name, int dim )
             | Const   ( object val )
             | BinOp   ( op op, expr lhs, expr rhs, bool is_non_neg )
+            | USub    ( expr arg, bool is_non_neg )
 
 } """,
     ext_types={

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -35,7 +35,11 @@ class IdentifierOrHole(str):
         raise ValueError(f"invalid identifier: {name}")
 
 
-front_ops = {"+", "-", "*", "/", "%", "<", ">", "<=", ">=", "==", "and", "or"}
+comparision_ops = {"<", ">", "<=", ">=", "=="}
+arithmetic_ops = {"+", "-", "*", "/", "%"}
+logical_ops = {"and", "or"}
+
+front_ops = comparision_ops | arithmetic_ops | logical_ops
 
 
 class Operator(str):

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -3071,6 +3071,8 @@ class DoSimplify(Cursor_Rewrite):
         elif e.op == "-":
             if is_const_zero(rhs):
                 return lhs
+            if is_const_zero(lhs):
+                return LoopIR.USub(rhs, rhs.type, rhs.srcinfo)
             if isinstance(lhs, LoopIR.BinOp) and lhs.op == "+":
                 if lhs.lhs == rhs:
                     return lhs.rhs

--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -7,7 +7,7 @@ import pysmt
 from asdl_adt import ADT
 from pysmt import shortcuts as SMT
 
-from .LoopIR import LoopIR, T, LoopIR_Rewrite, LoopIR_Do, FreeVars, Alpha_Rename
+from .LoopIR import LoopIR, T, LoopIR_Do, FreeVars, Alpha_Rename, comparision_ops
 from .LoopIR_dataflow import LoopIR_Dependencies
 from .LoopIR_scheduling import SchedulingError
 from .prelude import *
@@ -1125,8 +1125,13 @@ class Unification:
                     f"cannot unify a '{pe.op}' (@{pe.srcinfo}) with "
                     f"a '{be.op}'' (@{be.srcinfo})"
                 )
-            self.unify_e(pe.lhs, be.lhs)
-            self.unify_e(pe.rhs, be.rhs)
+            if pe.op in comparision_ops:
+                pe_rhs_sub_lhs = LoopIR.BinOp("-", pe.rhs, pe.lhs, T.index, pe.srcinfo)
+                be_rhs_sub_lhs = LoopIR.BinOp("-", be.rhs, be.lhs, T.index, be.srcinfo)
+                self.unify_e(pe_rhs_sub_lhs, be_rhs_sub_lhs)
+            else:
+                self.unify_e(pe.lhs, be.lhs)
+                self.unify_e(pe.rhs, be.rhs)
         elif isinstance(pe, LoopIR.BuiltIn):
             if pe.f != be.f:
                 raise UnificationError(

--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -1125,7 +1125,8 @@ class Unification:
                     f"cannot unify a '{pe.op}' (@{pe.srcinfo}) with "
                     f"a '{be.op}'' (@{be.srcinfo})"
                 )
-            if pe.op in comparision_ops:
+            exprs = [pe.rhs, pe.lhs, be.rhs, be.lhs]
+            if pe.op in comparision_ops and all(e.type.is_indexable() for e in exprs):
                 pe_rhs_sub_lhs = LoopIR.BinOp("-", pe.rhs, pe.lhs, T.index, pe.srcinfo)
                 be_rhs_sub_lhs = LoopIR.BinOp("-", be.rhs, be.lhs, T.index, be.srcinfo)
                 self.unify_e(pe_rhs_sub_lhs, be_rhs_sub_lhs)

--- a/tests/golden/test_codegen/test_CIR_USub.txt
+++ b/tests/golden/test_codegen/test_CIR_USub.txt
@@ -1,0 +1,65 @@
+
+#pragma once
+#ifndef TEST_H
+#define TEST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Compiler feature macros adapted from Hedley (public domain)
+// https://github.com/nemequ/hedley
+
+#if defined(__has_builtin)
+#  define EXO_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+#  define EXO_HAS_BUILTIN(builtin) (0)
+#endif
+
+#if EXO_HAS_BUILTIN(__builtin_assume)
+#  define EXO_ASSUME(expr) __builtin_assume(expr)
+#elif EXO_HAS_BUILTIN(__builtin_unreachable)
+#  define EXO_ASSUME(expr) \
+      ((void)((expr) ? 1 : (__builtin_unreachable(), 1)))
+#else
+#  define EXO_ASSUME(expr) ((void)(expr))
+#endif
+
+
+
+// foo(
+//     N : size,
+//     x : f32[N] @DRAM
+// )
+void foo( void *ctxt, int_fast32_t N, float* x );
+
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // TEST_H
+
+#include "test.h"
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+
+// foo(
+//     N : size,
+//     x : f32[N] @DRAM
+// )
+void foo( void *ctxt, int_fast32_t N, float* x ) {
+for (int_fast32_t i = 0; i < N; i++) {
+  x[-i + N - 1] = 0.0;
+}
+}
+

--- a/tests/golden/test_schedules/test_simplify3.txt
+++ b/tests/golden/test_schedules/test_simplify3.txt
@@ -1,4 +1,4 @@
 def foo(n: size, m: size):
     assert m == 1 and n == 1
     y: R[10] @ DRAM
-    y[0 - 8 * n + 10 * m] = 2.0
+    y[-(8 * n) + 10 * m] = 2.0

--- a/tests/golden/test_schedules/test_unify9.txt
+++ b/tests/golden/test_schedules/test_unify9.txt
@@ -1,5 +1,5 @@
 def foo(n: size, m: size, x: f32[n] @ DRAM):
-    assert 0 - m + n >= 1
-    assert 0 - m + n <= 8
+    assert -m + n >= 1
+    assert -m + n <= 8
     y: f32[8] @ DRAM
-    bar(y[0:8], x[0:8], 0 - m + n)
+    bar(y[0:8], x[0:8], -m + n)

--- a/tests/golden/test_schedules/test_unify9.txt
+++ b/tests/golden/test_schedules/test_unify9.txt
@@ -1,0 +1,5 @@
+def foo(n: size, m: size, x: f32[n] @ DRAM):
+    assert 0 - m + n >= 1
+    assert 0 - m + n <= 8
+    y: f32[8] @ DRAM
+    bar(y[0:8], x[0:8], 0 - m + n)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -503,3 +503,18 @@ def test_no_exo_floor_div_triangular_access(golden):
     code = f"{h_file}\n{c_file}"
 
     assert code == golden
+
+
+# Tests for CIR
+
+
+def test_CIR_USub(golden):
+    @proc
+    def foo(N: size, x: f32[N]):
+        for i in seq(0, N):
+            x[-i + N - 1] = 0.0
+
+    c_file, h_file = compile_procs_to_strings([foo], "test.h")
+    code = f"{h_file}\n{c_file}"
+
+    assert code == golden

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1597,6 +1597,26 @@ def test_unify8(golden):
     assert str(foo) == golden
 
 
+def test_unify9(golden):
+    @proc
+    def bar(dst: [f32][8], src: [f32][8], bound: size):
+        for i in seq(0, 8):
+            if i < bound:
+                dst[i] = src[i]
+
+    @proc
+    def foo(n: size, m: size, x: f32[n]):
+        assert n - m >= 1
+        assert n - m <= 8
+        y: f32[8]
+        for i in seq(0, 8):
+            if i + m < n:
+                y[i] = x[i]
+
+    foo = replace(foo, foo.find_loop("i"), bar)
+    assert str(simplify(foo)) == golden
+
+
 def test_inline_window(golden):
     @proc
     def foo(n: size, m: size, x: R[n, m]):


### PR DESCRIPTION
* lhs op rhs should be treated as `0 op rhs - lhs`, then run unification on `rhs - lhs`

Diagonsed by @yamaguchi1024, fix suggested by @skeqiqevian 

fixes: #496 