### PR TITLE
Allow dividing loops by 1

### DIFF
--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -1635,9 +1635,6 @@ def divide_loop(proc, loop_cursor, div_const, new_iters, tail="guard", perfect=F
         `    s[ i -> q * (e / q) + lo ]
     """
 
-    if div_const == 1:
-        raise ValueError("why are you trying to split by 1?")
-
     stmt = loop_cursor._impl
 
     ir, fwd = scheduling.DoSplit(

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -670,7 +670,7 @@ def DoSplit(loop_cursor, quot, outer_iter, inner_iter, tail="guard", perfect=Fal
         return LoopIR.Read(i, [], T.index, srcinfo)
 
     def ceildiv(lhs, rhs):
-        assert isinstance(rhs, LoopIR.Const) and rhs.val > 1
+        assert isinstance(rhs, LoopIR.Const) and rhs.val > 0
         rhs_1 = cnst(rhs.val - 1)
         return szop("/", szop("+", lhs, rhs_1), rhs)
 

--- a/tests/golden/test_schedules/test_divide_loop_by_1_cut.txt
+++ b/tests/golden/test_schedules/test_divide_loop_by_1_cut.txt
@@ -1,0 +1,10 @@
+def bar(n: size):
+    for io in seq(0, n / 1):
+        for ii in seq(0, 1):
+            pass
+    for ii in seq(0, n % 1):
+        pass
+def bar(n: size):
+    for io in seq(0, n):
+        for ii in seq(0, 1):
+            pass

--- a/tests/golden/test_schedules/test_divide_loop_by_1_guard.txt
+++ b/tests/golden/test_schedules/test_divide_loop_by_1_guard.txt
@@ -1,0 +1,10 @@
+def bar(n: size):
+    for io in seq(0, (n + 0) / 1):
+        for ii in seq(0, 1):
+            if 1 * io + ii < n:
+                pass
+def bar(n: size):
+    for io in seq(0, n):
+        for ii in seq(0, 1):
+            if ii + io < n:
+                pass

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1195,6 +1195,30 @@ def test_divide_loop_fail_nonzero_lo():
         bar = divide_loop(bar, "i", 4, ["io", "ii"], tail="guard")
 
 
+def test_divide_loop_by_1_guard(golden):
+    @proc
+    def bar(n: size):
+        for i in seq(0, n):
+            pass
+
+    bar1 = divide_loop(bar, bar.find_loop("i"), 1, ("io", "ii"), tail="guard")
+    bar2 = simplify(bar1)
+
+    assert f"{bar1}\n{bar2}" == golden
+
+
+def test_divide_loop_by_1_cut(golden):
+    @proc
+    def bar(n: size):
+        for i in seq(0, n):
+            pass
+
+    bar1 = divide_loop(bar, bar.find_loop("i"), 1, ("io", "ii"), tail="cut")
+    bar2 = simplify(bar1)
+
+    assert f"{bar1}\n{bar2}" == golden
+
+
 def test_simple_reorder(golden):
     @proc
     def bar(n: size, m: size, A: i8[n, m]):


### PR DESCRIPTION
* Often when you are scheduling step by step, you shouldn't really need to divide a loop by 1 which is why this was disabled.
* As you add more automation and implement more abstraction, you want to rely on symmetries in the structure of the AST and having this disabled is diruptive.