### PR TITLE
Forwarding for replacing nodes

### DIFF
--- a/tests/test_internal_cursors.py
+++ b/tests/test_internal_cursors.py
@@ -176,7 +176,7 @@ def test_fwd_replace_expr_node_2():
     stmt = foo.find("y + z").rhs()
     c = stmt._impl
     ir, fwd = c._replace(LoopIR.Const(42, T.size, c._node.srcinfo))
-    assert str(fwd(c)._node) == "42.0"
+    assert str(fwd(c)._node) == "42"
 
 
 def test_block_delete_whole_block(proc_bar, golden):


### PR DESCRIPTION
If we're going to claim that `_replace` is different from `_insert` and `_delete`, that should be true lol. 

TODO: I will refactor the large copy and pasted code from `_local_forward` into a separate function, since it now appears three times in the code (once in the original `_local_forward`, once for `_move`, and now once for `_replace`).
