### PR TITLE
Pattern matching on cursors

### DIFF
--- a/src/exo/API_cursors.py
+++ b/src/exo/API_cursors.py
@@ -5,17 +5,20 @@ from dataclasses import dataclass
 
 from typing import Optional, List, Any
 
-from . import API
+from . import API  # TODO: remove this circular import
+from .API_types import ExoType
 from .LoopIR import LoopIR
 from .configs import Config
 from .memory import Memory
 
 from . import internal_cursors as C
+from .pattern_match import match_pattern
 from .prelude import Sym
 
 # expose this particular exception as part of the API
 from .internal_cursors import InvalidCursorError
 from .LoopIR_pprint import _print_cursor
+from .LoopIR_scheduling import SchedulingError
 
 
 # --------------------------------------------------------------------------- #
@@ -124,6 +127,9 @@ class Cursor(ABC):
         elif isinstance(impl_parent._node, LoopIR.proc):
             return InvalidCursor()
         return lift_cursor(impl_parent, self._proc)
+
+    def find(self, pattern, many=False):
+        return find(self._impl, self._proc, pattern, many)
 
     def _child_node(self, *args, **kwargs):
         return lift_cursor(self._impl._child_node(*args, **kwargs), self._proc)
@@ -1003,6 +1009,38 @@ def lift_cursor(impl, proc):
 
     else:
         assert False, f"bad case: {type(impl)}"
+
+
+def find(scope: C, proc: API.Procedure, pattern: str, many: bool):
+    """
+    Find the most specific possible cursor for the given pattern in
+    the given scope of the proc. For example, a pattern matching a
+    single assignment statement will return an AssignCursor, not a
+    StmtCursor or BlockCursor.
+
+    If the optional parameter `many` is set to True, then return a list,
+    potentially containing more than one Cursor.
+
+    In any event, if no matches are found, a SchedulingError is raised.
+    """
+    if not isinstance(pattern, str):
+        raise TypeError("expected a pattern string")
+    default_match_no = None if many else 0
+    raw_cursors = match_pattern(
+        scope, pattern, call_depth=1, default_match_no=default_match_no
+    )
+    assert isinstance(raw_cursors, list)
+    cursors = []
+    for c in raw_cursors:
+        c = lift_cursor(c, proc)
+        if isinstance(c, (BlockCursor, ExprListCursor)) and len(c) == 1:
+            c = c[0]
+        cursors.append(c)
+
+    if not cursors:
+        raise SchedulingError("failed to find matches", pattern=pattern)
+
+    return cursors if many else cursors[0]
 
 
 # --------------------------------------------------------------------------- #

--- a/src/exo/API_types.py
+++ b/src/exo/API_types.py
@@ -1,2 +1,25 @@
+from enum import Enum, auto
+
+
 class ProcedureBase:
     pass
+
+
+class ExoType(Enum):
+    F32 = auto()
+    F64 = auto()
+    I8 = auto()
+    I32 = auto()
+    R = auto()
+    Index = auto()
+    Bool = auto()
+    Size = auto()
+
+    def is_indexable(self):
+        return self in [ExoType.Index, ExoType.Size]
+
+    def is_numeric(self):
+        return self in [ExoType.F32, ExoType.F64, ExoType.I8, ExoType.I32, ExoType.R]
+
+    def is_bool(self):
+        return self == ExoType.Bool

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -161,50 +161,6 @@ class Cursor_Rewrite(LoopIR_Rewrite):
 
 # --------------------------------------------------------------------------- #
 # --------------------------------------------------------------------------- #
-# Finding Names
-
-
-def name_plus_count(namestr):
-    results = re.search(r"^([a-zA-Z_]\w*)\s*(\#\s*([0-9]+))?$", namestr)
-    if not results:
-        raise TypeError(
-            "expected name pattern of the form\n"
-            "  ident (# integer)?\n"
-            "where ident is the name of a variable "
-            "and (e.g.) '#2' may optionally be attached to mean "
-            "'the second occurence of that identifier"
-        )
-
-    name = results[1]
-    count = int(results[3]) if results[3] else None
-    return name, count
-
-
-def iter_name_to_pattern(namestr):
-    name, count = name_plus_count(namestr)
-    if count is not None:
-        count = f" #{count}"
-    else:
-        count = ""
-
-    pattern = f"for {name} in _: _{count}"
-    return pattern
-
-
-def nested_iter_names_to_pattern(namestr, inner):
-    name, count = name_plus_count(namestr)
-    if count is not None:
-        count = f" #{count}"
-    else:
-        count = ""
-    assert is_valid_name(inner)
-
-    pattern = f"for {name} in _:\n  for {inner} in _: _{count}"
-    return pattern
-
-
-# --------------------------------------------------------------------------- #
-# --------------------------------------------------------------------------- #
 # Cursor form scheduling directive helpers
 
 
@@ -271,8 +227,7 @@ def _replace_writes(ir, fwd, c, sym, repl, only_replace_attrs=True):
         c, f"{repr(sym)} += _", use_sym_id=True
     )
     for block in matches:
-        # match_pattern on stmts return blocks
-        assert len(block) == 1
+        assert len(block) == 1  # match_pattern on stmts return blocks
         s = cur_fwd(block[0])
         if not (c_repl := repl(s)):
             continue

--- a/src/exo/pattern_match.py
+++ b/src/exo/pattern_match.py
@@ -57,7 +57,11 @@ def get_match_no(pattern_str: str) -> Optional[int]:
 
 
 def match_pattern(
-    context, pattern_str, call_depth=0, default_match_no=None, use_sym_id=False
+    context: Cursor,
+    pattern_str: str,
+    call_depth=0,
+    default_match_no=None,
+    use_sym_id=False,
 ):
     """
     If [default_match_no] is None, then all matches are returned

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -615,3 +615,18 @@ def test_get_enclosing_loop_fail():
         CursorNavigationError, match="scope is not an ancestor of cursor"
     ):
         c = get_stmt_within_scope(foo.find("x = _"), foo.find_loop("j"))
+
+
+def test_cursor_find_loop():
+    @proc
+    def foo(n: size, x: i8[n]):
+        for i in seq(0, n):
+            pass
+        if n > 1:
+            for i in seq(0, n):
+                x[i] = 0.0
+
+    i_loop2 = foo.find("for i in _:_ #1")
+    if_stmt = foo.find("if _: _ ")
+    i_loop_alternative = if_stmt.find("for i in _: _")
+    assert i_loop2 == i_loop_alternative


### PR DESCRIPTION
We currently allow users to pattern match via `proc.find`. We will extend that notion to `cursor.find`, enabling pattern matching for cursors.

Also did some miscellaneous code cleanup at the same time. There's a circular import between `API.py` and `API_cursors.py`. I couldn't think of a good way to break the dependency other than merging the two files, anyone have better ideas?