### PR TITLE
Implement remove_control operation

### DIFF
--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -2134,6 +2134,32 @@ def lift_scope(proc, scope_cursor):
     return Procedure(ir, _provenance_eq_Procedure=proc, _forward=fwd)
 
 
+@sched_op([IfCursorA])
+def remove_control(proc, if_cursor):
+    """
+    Eliminate the control introduced by the if statement and replace
+    the if statement by the code within the body.
+
+    This rewrite works only when effects (writes) within the body are only
+    observed when the if condition holds. As a result, if writes happen
+    to any procedure arguments or configuration state, then the rewrite
+    isn't allowed.
+
+    Note: that this is different from when the the condition is always
+    true or false, which is handled by `eliminate_dead_code`.
+
+    rewrite:
+        `if p:`
+        `    s1`
+        -> (assuming effects of `s1` are only observed when `p` holds)
+        `s1`
+    """
+    if_c = if_cursor._impl
+
+    ir, fwd = scheduling.DoRemoveControl(if_c)
+    return Procedure(ir, _provenance_eq_Procedure=proc, _forward=fwd)
+
+
 @sched_op([ForOrIfCursorA])
 def eliminate_dead_code(proc, stmt_cursor):
     """

--- a/src/exo/LoopIR.py
+++ b/src/exo/LoopIR.py
@@ -1088,6 +1088,28 @@ def is_const_zero(e):
     return isinstance(e, LoopIR.Const) and e.val == 0
 
 
+class GetConfigWrites(LoopIR_Do):
+    def __init__(self):
+        self.writes = []
+
+    def do_s(self, s):
+        if isinstance(s, LoopIR.WriteConfig):
+            self.writes.append(s)
+        elif isinstance(s, LoopIR.Call):
+            self.writes += get_config_writes_of_stmts(s.f.body)
+        super().do_s(s)
+
+    # early exit
+    def do_e(self, e):
+        return
+
+
+def get_config_writes_of_stmts(stmts):
+    gwc = GetConfigWrites()
+    gwc.do_stmts(stmts)
+    return gwc.writes
+
+
 class FreeVars(LoopIR_Do):
     def __init__(self, node):
         assert isinstance(node, list)

--- a/src/exo/new_eff.py
+++ b/src/exo/new_eff.py
@@ -731,7 +731,6 @@ def _lsstr(ls, prec=0):
         typ = f":{ls.type}" if ls.type else ""
         return f"{{({ls.name},{coords}{typ})}}"
     elif isinstance(ls, LS.WholeBuf):
-        coords = ",".join([str(a) for a in ls.coords])
         return f"{{{ls.name}|{ls.ndim}}}"
     elif isinstance(ls, (LS.Union, LS.Isct, LS.Diff)):
         if isinstance(ls, LS.Union):
@@ -2013,6 +2012,10 @@ def Check_BufferReduceOnly(proc, stmts, buf, ndim):
 
 
 def Check_Bounds(proc, alloc_stmt, block):
+    """
+    Check bounds accesses to the `alloc_stmt` within the `block`.
+    `alloc_stmt` must not be within the `block`.
+    """
     if len(block) == 0:
         return
     ctxt = ContextExtraction(proc, block)

--- a/src/exo/stdlib/scheduling.py
+++ b/src/exo/stdlib/scheduling.py
@@ -83,6 +83,7 @@ from ..API_scheduling import (
     #
     # guard rewriting
     lift_scope,
+    remove_control,
     eliminate_dead_code,
     specialize,
     #

--- a/tests/golden/test_schedules/test_remove_control.txt
+++ b/tests/golden/test_schedules/test_remove_control.txt
@@ -1,0 +1,4 @@
+def foo(b: f32 @ DRAM):
+    for i in seq(0, 8):
+        a: f32 @ DRAM
+        a = 1.0

--- a/tests/golden/test_schedules/test_remove_control_after_hoist.txt
+++ b/tests/golden/test_schedules/test_remove_control_after_hoist.txt
@@ -1,0 +1,5 @@
+def foo(n: size, b: f32 @ DRAM):
+    a: f32 @ DRAM
+    a = 1.0
+    for i in seq(0, n / 8):
+        b += a

--- a/tests/golden/test_schedules/test_remove_control_broadcast.txt
+++ b/tests/golden/test_schedules/test_remove_control_broadcast.txt
@@ -1,0 +1,7 @@
+def foo(n: size, c: f32[n] @ DRAM):
+    for io in seq(0, (n + 3) / 4):
+        for ii in seq(0, 4):
+            a: f32 @ DRAM
+            a = 1.0
+            if 4 * io + ii < n:
+                c[4 * io + ii] += a


### PR DESCRIPTION
* Remove control and inline the body of an if statement.
* Supported when effects of the statements within the body are only observed when the if condition holds and we don't introduce any out-of-bound accesses.