### PR TITLE
Upgrade z3-solver version to 4.12.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pytest-xdist==3.0.2
 pytest==7.1.1
 tox==3.24.5
 yapf==0.32.0
-z3-solver==4.8.15.0
+z3-solver==4.12.4.0

--- a/tests/golden/test_schedules/test_remove_loop_deterministic.txt
+++ b/tests/golden/test_schedules/test_remove_loop_deterministic.txt
@@ -1,0 +1,5 @@
+def foo(M: size, N: size, K: size, A: f32[M, N] @ DRAM):
+    if K / 4 > 0:
+        for i in seq(0, M):
+            for j in seq(0, N):
+                A[i, j] = 1.0

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -575,6 +575,21 @@ def test_remove_loop_fail(golden):
         remove_loop(foo, "for i in _:_")
 
 
+def test_remove_loop_deterministic(golden):
+    @proc
+    def foo(M: size, N: size, K: size, A: f32[M, N]):
+        for k in seq(0, K / 4):
+            for i in seq(0, M):
+                for j in seq(0, N):
+                    A[i, j] = 1.0
+
+    # An older Z3 version caused check within remove_loop
+    # to fail non-deterministically (return an unknwon result).
+    # This test make sure that over a few runs, it always passes.
+    for i in range(10):
+        assert golden == str(remove_loop(foo, "k"))
+
+
 def test_sink_alloc_simple_for_loop(golden):
     @proc
     def foo():

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -587,7 +587,7 @@ def test_remove_loop_deterministic(golden):
     # to fail non-deterministically (return an unknwon result).
     # This test make sure that over a few runs, it always passes.
     for i in range(10):
-        assert golden == str(remove_loop(foo, "k"))
+        assert str(remove_loop(foo, "k")) == golden
 
 
 def test_sink_alloc_simple_for_loop(golden):


### PR DESCRIPTION
* The older z3 version was causing remove_loop to fail non-deterministically.
* Add a test that runs the flaky test multiple times to make sure it always passes.