### PR TITLE
Fix two bugs in unroll_buffer

### DIFF
--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -4065,7 +4065,7 @@ def DoUnrollBuffer(alloc_cursor, dim):
 
             used_allocs.add(e.idx[dim].val)
 
-            sym = [e.idx[dim].val]
+            sym = buf_syms[e.idx[dim].val]
             new_idx = e.idx.copy()
             del new_idx[dim]
 
@@ -4112,7 +4112,10 @@ def DoUnrollBuffer(alloc_cursor, dim):
 
     new_shape = alloc_stmt.type.shape().copy()
     del new_shape[dim]
-    new_type = LoopIR.Tensor(new_shape, False, alloc_stmt.type.basetype())
+    if len(new_shape):
+        new_type = LoopIR.Tensor(new_shape, False, alloc_stmt.type.basetype())
+    else:
+        new_type = alloc_stmt.type.basetype()
 
     new_allocs = []
     for itr in used_allocs:

--- a/tests/golden/test_schedules/test_unroll_buffer6.txt
+++ b/tests/golden/test_schedules/test_unroll_buffer6.txt
@@ -1,0 +1,7 @@
+def foo():
+    a_0: f32 @ DRAM
+    a_1: f32 @ DRAM
+    b_0: f32 @ DRAM
+    b_1: f32 @ DRAM
+    a_0 = b_0
+    a_1 = b_1

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -3596,6 +3596,19 @@ def test_unroll_buffer5():
         bar = unroll_buffer(bar, "tmp_a : _", 0)
 
 
+def test_unroll_buffer6(golden):
+    @proc
+    def foo():
+        a: f32[2]
+        b: f32[2]
+        a[0] = b[0]
+        a[1] = b[1]
+
+    foo = unroll_buffer(foo, "a : _", 0)
+    foo = unroll_buffer(foo, "b : _", 0)
+    assert str(foo) == golden
+
+
 def test_parallelize_loop(golden):
     @proc
     def foo(A: i8[10]):


### PR DESCRIPTION
* A typo when getting the symbol name of the new buffer in Read case.
* A bug in the edge case (buffer with no dimensions) when constructing the new type.