### PR TITLE
Update the SDE version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Setup SDE binaries
         if: runner.os != 'macOS'
-        uses: petarpetrovt/setup-sde@v2.1
+        uses: petarpetrovt/setup-sde@v2.3
 
       - name: Install Clang 13 (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
At the time of this commit, the SDE version 2.1 setup was receiving an HTTP error of 403. See the following action:
https://github.com/exo-lang/exo/actions/runs/7574531469/job/20669540399?pr=550

This commit updates the SDE version to the most recent version supported according to:
https://github.com/petarpetrovt/setup-sde/blob/2b2adf3ea804bbb573684eda6ec8329f36970e6c/README.md?plain=1#L16