### PR TITLE
Fix bug in inline_assign

### DIFF
--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -508,7 +508,8 @@ def DoInlineAssign(c1):
         )
 
     ir, fwd = c1._delete()
-    pat = f"{s1.name}[{','.join([str(idx) for idx in s1.idx])}]"
+    idx = f"[{','.join([str(idx) for idx in s1.idx])}]" if s1.idx else ""
+    pat = f"{s1.name}{idx}"
     for c in after_assign:
         ir, fwd = _replace_pats(
             ir, fwd, c, pat, mk_inline_expr, only_replace_attrs=False, use_sym_id=False

--- a/tests/golden/test_schedules/test_inline_assign_scalar.txt
+++ b/tests/golden/test_schedules/test_inline_assign_scalar.txt
@@ -1,0 +1,3 @@
+def foo(b: f32 @ DRAM):
+    a: f32 @ DRAM
+    b = 1.0

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1449,6 +1449,17 @@ def test_inline_assign(golden):
     assert str(foo) == golden
 
 
+def test_inline_assign_scalar(golden):
+    @proc
+    def foo(b: f32):
+        a: f32
+        a = 1.0
+        b = a
+
+    foo = inline_assign(foo, foo.find("a = _"))
+    assert str(foo) == golden
+
+
 def test_inline_assign_fail():
     @proc
     def foo(n: size, y: i8[n]):


### PR DESCRIPTION
* The code was constructing a [] access for the buffer regardless of whether it was a tesnor or a scalar.