### PR TITLE
Remove unsafe_disable_checks from expand_dim

### DIFF
--- a/.github/workflows/blas.yml
+++ b/.github/workflows/blas.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Install Google benchmark
         run: git clone https://github.com/google/benchmark; cmake -S benchmark -B benchmark/build -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_TESTING=NO ; cmake --build benchmark/build; cmake --install benchmark/build --prefix ~/.local
+        if: ${{matrix.runner == 'ubuntu-latest'}}
 
       - name: Checkout BLAS repo
         uses: actions/checkout@v4

--- a/apps/aarch64/sgemm/demo_stage.py
+++ b/apps/aarch64/sgemm/demo_stage.py
@@ -198,7 +198,7 @@ sgemm_tiled = finish_sgemm_tiled()
 def stage_C_microkernel(p=neon_microkernel):
     p = stage_mem(p, 'C[_] += _', 'C[i, 4 * jo + ji]', 'C_reg')
     for iname in reversed(['i','jo','ji']):
-        p = expand_dim(p, 'C_reg', 4, iname, unsafe_disable_checks=True)
+        p = expand_dim(p, 'C_reg', 4, iname)
     p = lift_alloc(p, 'C_reg', n_lifts=4)
     p = autofission(p, p.find('C_reg[_] = _').after(), n_lifts=4)
     p = autofission(p, p.find('C[_] = _').before(), n_lifts=4)
@@ -215,7 +215,7 @@ neon_microkernel = stage_C_microkernel()
 def stage_A_B_microkernel(p=neon_microkernel):
     for buf in ('A','B'):
         p = bind_expr(p, f'{buf}[_]', f'{buf}_vec')
-        p = expand_dim(p, f'{buf}_vec', 4, 'ji', unsafe_disable_checks=True)
+        p = expand_dim(p, f'{buf}_vec', 4, 'ji')
         p = lift_alloc(p, f'{buf}_vec')
         p = fission(p, p.find(f'{buf}_vec[_] = _').after())
         p = set_memory(p, f'{buf}_vec', Neon)

--- a/apps/aarch64/sgemm/sgemm.py
+++ b/apps/aarch64/sgemm/sgemm.py
@@ -88,7 +88,7 @@ neon_microkernel = make_neon_microkernel()
 def stage_C_microkernel(p=neon_microkernel):
     p = stage_mem(p, "C[_] += _", "C[i, 4 * jo + ji]", "C_reg")
     for iname in reversed(["i", "jo", "ji"]):
-        p = expand_dim(p, "C_reg", 4, iname, unsafe_disable_checks=True)
+        p = expand_dim(p, "C_reg", 4, iname)
     p = lift_alloc(p, "C_reg", n_lifts=4)
     p = autofission(p, p.find("C_reg[_] = _").after(), n_lifts=4)
     p = autofission(p, p.find("C[_] = _").before(), n_lifts=4)
@@ -105,7 +105,7 @@ neon_microkernel = stage_C_microkernel()
 def stage_A_B_microkernel(p=neon_microkernel):
     for buf in ("A", "B"):
         p = bind_expr(p, f"{buf}[_]", f"{buf}_vec")
-        p = expand_dim(p, f"{buf}_vec", 4, "ji", unsafe_disable_checks=True)
+        p = expand_dim(p, f"{buf}_vec", 4, "ji")
         p = lift_alloc(p, f"{buf}_vec")
         p = fission(p, p.find(f"{buf}_vec[_] = _").after())
         p = set_memory(p, f"{buf}_vec", Neon)

--- a/apps/gemmini/src/exo/conv.py
+++ b/apps/gemmini/src/exo/conv.py
@@ -181,13 +181,9 @@ def schedule_conv_3():
     conv = old_fission_after(conv, "for ocol_o in _:_ #0")
     conv = old_reorder(conv, "orow ocol_o")
     conv = old_split(conv, "orow", 28, ["orow_o", "orow_i"], perfect=True)
-    # FIXME(#133): Remove unsafe_disable_checks once we have new effectcheck working
-    conv = expand_dim(
-        conv, "i_s: i8[_]", "30", "krow + orow_i", unsafe_disable_checks=True
-    )
-    conv = expand_dim(
-        conv, "i_s: i8[_] #1", "30", "krow + orow_i", unsafe_disable_checks=True
-    )
+    conv = expand_dim(conv, "i_s: i8[_]", "30", "krow + orow_i")
+    conv = expand_dim(conv, "i_s: i8[_] #1", "30", "krow + orow_i")
+
     # TODO: We should definitely use repeat for this!
     conv = old_lift_alloc(conv, "i_s : _ #0", n_lifts=5, keep_dims=False)
     conv = old_lift_alloc(conv, "i_s : _ #1", n_lifts=4, keep_dims=False)
@@ -318,13 +314,8 @@ def schedule_conv_17():
     conv = old_unroll(conv, "ocol_o")
     conv = old_fission_after(conv, "for och_o in _:_ #2", n_lifts=2)
     conv = old_split(conv, "orow", 14, ["orow_o", "orow_i"], perfect=True)
-    # FIXME(#133): Remove unsafe_disable_checks once we have new effectcheck working
-    conv = expand_dim(
-        conv, "i_s: i8[_]", "16", "krow + orow_i", unsafe_disable_checks=True
-    )
-    conv = expand_dim(
-        conv, "i_s: i8[_] #1", "16", "krow + orow_i", unsafe_disable_checks=True
-    )
+    conv = expand_dim(conv, "i_s: i8[_]", "16", "krow + orow_i")
+    conv = expand_dim(conv, "i_s: i8[_] #1", "16", "krow + orow_i")
     conv = old_lift_alloc(conv, "w_s : _", n_lifts=2)
     conv = old_split(conv, "b", 4, ["bo", "bi"], perfect=True)
     conv = old_lift_alloc(conv, "i_s : _", n_lifts=4, keep_dims=False)
@@ -453,10 +444,7 @@ def schedule_conv_30():
 
     conv = old_lift_alloc(conv, "w_s : _", n_lifts=2)
     conv = old_split(conv, "orow", 7, ["orow_o", "orow_i"], perfect=True)
-    # FIXME(#133): Remove unsafe_disable_checks once we have new effectcheck working
-    conv = expand_dim(
-        conv, "i_s: i8[_]", "9", "krow + orow_i", unsafe_disable_checks=True
-    )
+    conv = expand_dim(conv, "i_s: i8[_]", "9", "krow + orow_i")
     conv = old_lift_alloc(conv, "res : _", n_lifts=1)
     conv = old_lift_alloc(conv, "i_s : _", n_lifts=5, keep_dims=False)
     conv = old_lift_alloc(conv, "w_s : _", n_lifts=4, keep_dims=False)

--- a/apps/x86/sgemm/sgemm.py
+++ b/apps/x86/sgemm/sgemm.py
@@ -183,7 +183,7 @@ def make_right_panel_kernel_opt(p=right_panel_kernel):
     #
     def stage_input(p, expr, new_buf, n_lifts=1):
         p = bind_expr(p, expr, new_buf)
-        p = expand_dim(p, new_buf, 16, "ji", unsafe_disable_checks=True)
+        p = expand_dim(p, new_buf, 16, "ji")
         p = lift_alloc(p, new_buf, n_lifts=n_lifts)
         p = set_memory(p, new_buf, AVX512)
         p = fission(p, p.find(f"{new_buf} = _").after(), n_lifts=n_lifts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ black==22.10.0
 coverage==6.3.2
 jupyter-contrib-nbextensions==0.5.1
 numpy==1.23.4
-pre-commit==2.20.0
+pre-commit==3.6.0
 pytest-cov==3.0.0
 pytest-xdist==3.0.2
 pytest==7.1.1

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -1220,8 +1220,8 @@ def resize_dim(proc, buf_cursor, dim_idx, size, offset):
     return Procedure(ir, _provenance_eq_Procedure=proc, _forward=fwd)
 
 
-@sched_op([AllocCursorA, NewExprA("buf_cursor"), NewExprA("buf_cursor"), BoolA])
-def expand_dim(proc, buf_cursor, alloc_dim, indexing_expr, unsafe_disable_checks=False):
+@sched_op([AllocCursorA, NewExprA("buf_cursor"), NewExprA("buf_cursor")])
+def expand_dim(proc, buf_cursor, alloc_dim, indexing_expr):
     """
     TODO: rename this...expand_dim sounds like its increasing the size
     of a dimension. It should be more like add_dim.

--- a/tests/pldi22/test_gemmini_conv_ae.py
+++ b/tests/pldi22/test_gemmini_conv_ae.py
@@ -128,9 +128,8 @@ def test_conv_ae(golden):
     gemmini = old_fission_after(gemmini, "for ocol_o in _:_ #0")
     gemmini = old_reorder(gemmini, "orow ocol_o")
     gemmini = old_split(gemmini, "orow", 28, ["orow_o", "orow_i"], perfect=True)
-    gemmini = expand_dim(
-        gemmini, "i_s: i8[_]", "30", "krow + orow_i", unsafe_disable_checks=True
-    )
+    gemmini = expand_dim(gemmini, "i_s: i8[_]", "30", "krow + orow_i")
+
     # TODO: Use cursor + repeat to improve this!
     gemmini = old_lift_alloc(gemmini, "i_s : _ #0", n_lifts=5, keep_dims=False)
     gemmini = old_lift_alloc(gemmini, "i_s : _ #1", n_lifts=4, keep_dims=False)

--- a/tests/test_neon.py
+++ b/tests/test_neon.py
@@ -102,7 +102,7 @@ def test_neon_vfmla():
 
     def simple_vfmla(p=vfmla):
         p = stage_mem(p, "C[_] += _", "C[i]", "C_reg")
-        p = expand_dim(p, "C_reg", 4, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "C_reg", 4, "i")
         p = lift_alloc(p, "C_reg", n_lifts=2)
         p = autofission(p, p.find("C_reg[_] = _").after(), n_lifts=2)
         p = autofission(p, p.find("C[_] = _").before(), n_lifts=2)
@@ -111,14 +111,14 @@ def test_neon_vfmla():
         p = set_memory(p, "C_reg", Neon)
 
         p = bind_expr(p, "A[_]", "A_vec")
-        p = expand_dim(p, "A_vec", 4, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "A_vec", 4, "i")
         p = lift_alloc(p, "A_vec", n_lifts=2)
         p = autofission(p, p.find("A_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for i in _: _ #0", neon_vld_4xf32)
         p = set_memory(p, "A_vec", Neon)
 
         p = bind_expr(p, "B[_]", "B_vec")
-        p = expand_dim(p, "B_vec", 4, "l", unsafe_disable_checks=True)
+        p = expand_dim(p, "B_vec", 4, "l")
         p = lift_alloc(p, "B_vec", n_lifts=2)
         p = autofission(p, p.find("B_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for l in _: _ #0", neon_vld_4xf32)
@@ -155,7 +155,7 @@ def test_neon_vfmla_f16():
 
     def simple_vfmla_f16(p=vfmla_f16):
         p = stage_mem(p, "C[_] += _", "C[i]", "C_reg")
-        p = expand_dim(p, "C_reg", 8, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "C_reg", 8, "i")
         p = lift_alloc(p, "C_reg", n_lifts=2)
         p = autofission(p, p.find("C_reg[_] = _").after(), n_lifts=2)
         p = autofission(p, p.find("C[_] = _").before(), n_lifts=2)
@@ -164,14 +164,14 @@ def test_neon_vfmla_f16():
         p = set_memory(p, "C_reg", Neon)
 
         p = bind_expr(p, "A[_]", "A_vec")
-        p = expand_dim(p, "A_vec", 8, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "A_vec", 8, "i")
         p = lift_alloc(p, "A_vec", n_lifts=2)
         p = autofission(p, p.find("A_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for i in _: _ #0", neon_vld_8xf16)
         p = set_memory(p, "A_vec", Neon)
 
         p = bind_expr(p, "B[_]", "B_vec")
-        p = expand_dim(p, "B_vec", 8, "l", unsafe_disable_checks=True)
+        p = expand_dim(p, "B_vec", 8, "l")
         p = lift_alloc(p, "B_vec", n_lifts=2)
         p = autofission(p, p.find("B_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for l in _: _ #0", neon_vld_8xf16)
@@ -208,7 +208,7 @@ def test_neon_vfmla_f16():
 
     def simple_vfmla_f16(p=vfmla_f16):
         p = stage_mem(p, "C[_] += _", "C[i]", "C_reg")
-        p = expand_dim(p, "C_reg", 8, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "C_reg", 8, "i")
         p = lift_alloc(p, "C_reg", n_lifts=2)
         p = autofission(p, p.find("C_reg[_] = _").after(), n_lifts=2)
         p = autofission(p, p.find("C[_] = _").before(), n_lifts=2)
@@ -217,14 +217,14 @@ def test_neon_vfmla_f16():
         p = set_memory(p, "C_reg", Neon)
 
         p = bind_expr(p, "A[_]", "A_vec")
-        p = expand_dim(p, "A_vec", 8, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "A_vec", 8, "i")
         p = lift_alloc(p, "A_vec", n_lifts=2)
         p = autofission(p, p.find("A_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for i in _: _ #0", neon_vld_8xf16)
         p = set_memory(p, "A_vec", Neon)
 
         p = bind_expr(p, "B[_]", "B_vec")
-        p = expand_dim(p, "B_vec", 8, "l", unsafe_disable_checks=True)
+        p = expand_dim(p, "B_vec", 8, "l")
         p = lift_alloc(p, "B_vec", n_lifts=2)
         p = autofission(p, p.find("B_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for l in _: _ #0", neon_vld_8xf16)
@@ -261,7 +261,7 @@ def test_neon_vfmla_f16():
 
     def simple_vfmla_f16(p=vfmla_f16):
         p = stage_mem(p, "C[_] += _", "C[i]", "C_reg")
-        p = expand_dim(p, "C_reg", 8, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "C_reg", 8, "i")
         p = lift_alloc(p, "C_reg", n_lifts=2)
         p = autofission(p, p.find("C_reg[_] = _").after(), n_lifts=2)
         p = autofission(p, p.find("C[_] = _").before(), n_lifts=2)
@@ -270,14 +270,14 @@ def test_neon_vfmla_f16():
         p = set_memory(p, "C_reg", Neon)
 
         p = bind_expr(p, "A[_]", "A_vec")
-        p = expand_dim(p, "A_vec", 8, "i", unsafe_disable_checks=True)
+        p = expand_dim(p, "A_vec", 8, "i")
         p = lift_alloc(p, "A_vec", n_lifts=2)
         p = autofission(p, p.find("A_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for i in _: _ #0", neon_vld_8xf16)
         p = set_memory(p, "A_vec", Neon)
 
         p = bind_expr(p, "B[_]", "B_vec")
-        p = expand_dim(p, "B_vec", 8, "l", unsafe_disable_checks=True)
+        p = expand_dim(p, "B_vec", 8, "l")
         p = lift_alloc(p, "B_vec", n_lifts=2)
         p = autofission(p, p.find("B_vec[_] = _").after(), n_lifts=2)
         p = replace(p, "for l in _: _ #0", neon_vld_8xf16)

--- a/tests/test_rvv.py
+++ b/tests/test_rvv.py
@@ -36,8 +36,8 @@ def test_rvv_vfmul():
         p = divide_loop(p, "i", 4, ["io", "ii"], perfect=True)
         t = "C[4 * io + ii]"
         p = stage_mem(p, "C[_] += _", t, "C_reg")
-        p = expand_dim(p, "C_reg", 4, "ii", unsafe_disable_checks=True)
-        p = expand_dim(p, "C_reg", 2, "io", unsafe_disable_checks=True)
+        p = expand_dim(p, "C_reg", 4, "ii")
+        p = expand_dim(p, "C_reg", 2, "io")
 
         p = lift_alloc(p, "C_reg", n_lifts=2)
         p = autofission(p, p.find("C_reg[_] = _").after(), n_lifts=2)
@@ -49,8 +49,8 @@ def test_rvv_vfmul():
         p = set_memory(p, "C_reg", RVV)
         for buf in ["A", "B"]:
             p = bind_expr(p, f"{buf}[_]", f"{buf}_vec")
-            p = expand_dim(p, f"{buf}_vec", 4, "ii", unsafe_disable_checks=True)
-            p = expand_dim(p, f"{buf}_vec", 2, "io", unsafe_disable_checks=True)
+            p = expand_dim(p, f"{buf}_vec", 4, "ii")
+            p = expand_dim(p, f"{buf}_vec", 2, "io")
             p = lift_alloc(p, f"{buf}_vec", n_lifts=2)
             p = autofission(p, p.find(f"{buf}_vec[_] = _").after(), n_lifts=2)
             p = replace(p, "for ii in _: _ #0", rvv_vld_4xf32)


### PR DESCRIPTION
Closes #133

This PR removes unsafe_disable_checks from expand_dim, which was not used to skip checks anyway (see src/exo/API_scheduling.py)