### PR TITLE
Fix bug in stage_mem

### DIFF
--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -3811,7 +3811,7 @@ def DoStageMem(block_cursor, buf_name, w_exprs, new_name, use_accum_zero=False):
         # the forwarded version. However, in all the current callees, the
         # statement would have been just constructed and if you try to forward
         # you get an error.
-        ir, fwd_wrap = ctxt_stmt_c.parent().body()._wrap(guard_wrapper, "body")
+        ir, fwd_wrap = ctxt_stmt_c.as_block()._wrap(guard_wrapper, "body")
         fwd = _compose(fwd_wrap, fwd)
 
         return ir, fwd

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -3227,9 +3227,12 @@ class DoSimplify(Cursor_Rewrite):
         super().__init__(proc)
 
         # might need to update IR with predicate changes
-        if new_preds := self.map_exprs(self.ir.preds):
-            # TODO KQ: is this line covered? do we not need to forward here?
-            self.ir = self.ir.update(preds=new_preds)
+        new_preds = self.map_exprs(self.ir.preds)
+        if new_preds:
+            self.ir, fwd = (
+                ic.Cursor.create(self.ir)._child_block("preds")._replace(new_preds)
+            )
+            self.fwd = _compose(fwd, self.fwd)
 
     def cfold(self, op, lhs, rhs):
         if op == "+":

--- a/tests/golden/test_schedules/test_stage_mem_out_of_bound_point.txt
+++ b/tests/golden/test_schedules/test_stage_mem_out_of_bound_point.txt
@@ -1,0 +1,10 @@
+def foo(n: size, m: size, x: f32[n] @ DRAM, y: f32[n] @ DRAM):
+    assert m >= n
+    for i in seq(0, m):
+        tmp: f32 @ DRAM
+        if i < n:
+            tmp = x[i]
+        if i < n:
+            y[i] = tmp
+        if i < n:
+            y[i] = tmp

--- a/tests/golden/test_schedules/test_stage_mem_out_of_bound_point.txt
+++ b/tests/golden/test_schedules/test_stage_mem_out_of_bound_point.txt
@@ -6,5 +6,3 @@ def foo(n: size, m: size, x: f32[n] @ DRAM, y: f32[n] @ DRAM):
             tmp = x[i]
         if i < n:
             y[i] = tmp
-        if i < n:
-            y[i] = tmp

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -158,6 +158,19 @@ def test_simplify_forwarding(golden):
     assert str(foo1.forward(stmt)._impl._node) == golden
 
 
+def test_simplify_predicates_forwarding():
+    @proc
+    def foo(n: size):
+        assert n >= 1
+        for i in seq(0, n):
+            pass
+
+    loop = foo.find_loop("i")
+    foo = simplify(foo)
+    loop = foo.forward(loop)
+    assert loop == foo.find_loop("i")
+
+
 def test_type_and_shape_introspection():
     @proc
     def foo(n: size, m: index, flag: bool):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -2603,6 +2603,20 @@ def test_stage_mem_out_of_bound_block(golden):
     assert str(axpy) == golden
 
 
+def test_stage_mem_out_of_bound_point(golden):
+    @proc
+    def foo(n: size, m: size, x: f32[n], y: f32[n]):
+        assert m >= n
+        for i in seq(0, m):
+            if i < n:
+                y[i] = x[i]
+            if i < n:
+                y[i] = x[i]
+
+    foo = stage_mem(foo, foo.find_loop("i").body(), "x[i]", "tmp")
+    assert str(foo) == golden
+
+
 def test_new_expr_multi_vars(golden):
     @proc
     def bar(n: size, arr: R[n] @ DRAM):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -2610,8 +2610,6 @@ def test_stage_mem_out_of_bound_point(golden):
         for i in seq(0, m):
             if i < n:
                 y[i] = x[i]
-            if i < n:
-                y[i] = x[i]
 
     foo = stage_mem(foo, foo.find_loop("i").body(), "x[i]", "tmp")
     assert str(foo) == golden


### PR DESCRIPTION
* When wrapping load/stores with guard, the code was doing a roundabout
    approach to get the block of the load/store which doesn't work when
    the load stage is simply a statement and not a loop nest. The correct
    way to get such a block is to simply use as_block()