### PR TITLE
Unify index inequalities with different ops

### DIFF
--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -1096,6 +1096,8 @@ class Unification:
         elif e.op == ">=":
             # rewrite `lhs >= rhs` into `0 < lhs - rhs + 1`
             return add1(sub(e.lhs, e.rhs))
+        else:
+            assert False, f"Unreachable op found: {e.op}"
 
     def unify_e(self, pe, be):
         if pe.type.is_indexable() != be.type.is_indexable() or (pe.type == T.bool) != (

--- a/src/exo/LoopIR_unification.py
+++ b/src/exo/LoopIR_unification.py
@@ -1075,6 +1075,28 @@ class Unification:
                 f"type {bt} (@{bnode.srcinfo})"
             )
 
+    @staticmethod
+    def comparision_to_unification_expr(e):
+        def sub(lhs, rhs):
+            return LoopIR.BinOp("-", lhs, rhs, T.index, null_srcinfo())
+
+        def add1(e):
+            one = LoopIR.Const(1, T.int, null_srcinfo())
+            return LoopIR.BinOp("+", e, one, T.index, null_srcinfo())
+
+        if e.op == "<" or e.op == "==":
+            # rewrite `lhs op rhs` into `0 op rhs - lhs`
+            return sub(e.rhs, e.lhs)
+        elif e.op == "<=":
+            # rewrite `lhs <= rhs` into `0 < rhs - lhs + 1`
+            return add1(sub(e.rhs, e.lhs))
+        elif e.op == ">":
+            # rewrite `lhs > rhs` into `0 < lhs - rhs`
+            return sub(e.lhs, e.rhs)
+        elif e.op == ">=":
+            # rewrite `lhs >= rhs` into `0 < lhs - rhs + 1`
+            return add1(sub(e.lhs, e.rhs))
+
     def unify_e(self, pe, be):
         if pe.type.is_indexable() != be.type.is_indexable() or (pe.type == T.bool) != (
             be.type == T.bool
@@ -1120,19 +1142,23 @@ class Unification:
         elif isinstance(pe, LoopIR.USub):
             self.unify_e(pe.arg, be.arg)
         elif isinstance(pe, LoopIR.BinOp):
+            exprs = [pe.rhs, pe.lhs, be.rhs, be.lhs]
+            if pe.op in comparision_ops and all(e.type.is_indexable() for e in exprs):
+                inequality_ops = comparision_ops - {"=="}
+                if pe.op == be.op or (
+                    pe.op in inequality_ops and be.op in inequality_ops
+                ):
+                    pe_e = self.comparision_to_unification_expr(pe)
+                    be_e = self.comparision_to_unification_expr(be)
+                    self.unify_e(pe_e, be_e)
+                    return
             if pe.op != be.op:
                 raise UnificationError(
                     f"cannot unify a '{pe.op}' (@{pe.srcinfo}) with "
                     f"a '{be.op}'' (@{be.srcinfo})"
                 )
-            exprs = [pe.rhs, pe.lhs, be.rhs, be.lhs]
-            if pe.op in comparision_ops and all(e.type.is_indexable() for e in exprs):
-                pe_rhs_sub_lhs = LoopIR.BinOp("-", pe.rhs, pe.lhs, T.index, pe.srcinfo)
-                be_rhs_sub_lhs = LoopIR.BinOp("-", be.rhs, be.lhs, T.index, be.srcinfo)
-                self.unify_e(pe_rhs_sub_lhs, be_rhs_sub_lhs)
-            else:
-                self.unify_e(pe.lhs, be.lhs)
-                self.unify_e(pe.rhs, be.rhs)
+            self.unify_e(pe.lhs, be.lhs)
+            self.unify_e(pe.rhs, be.rhs)
         elif isinstance(pe, LoopIR.BuiltIn):
             if pe.f != be.f:
                 raise UnificationError(

--- a/tests/golden/test_schedules/test_unify10.txt
+++ b/tests/golden/test_schedules/test_unify10.txt
@@ -1,0 +1,5 @@
+def foo(n: size, m: size, x: f32[n] @ DRAM):
+    assert -m + n >= 1
+    assert -m + n <= 8
+    y: f32[8] @ DRAM
+    bar(y[0:8], x[0:8], 1 - m + n)

--- a/tests/golden/test_schedules/test_unify11.txt
+++ b/tests/golden/test_schedules/test_unify11.txt
@@ -1,0 +1,5 @@
+def foo(n: size, m: size, x: f32[n] @ DRAM):
+    assert -m + n >= 1
+    assert -m + n <= 8
+    y: f32[8] @ DRAM
+    bar(y[0:8], x[0:8], -n + m)

--- a/tests/golden/test_schedules/test_unify12.txt
+++ b/tests/golden/test_schedules/test_unify12.txt
@@ -1,0 +1,5 @@
+def foo(n: size, m: size, x: f32[n] @ DRAM):
+    assert -m + n >= 1
+    assert -m + n <= 8
+    y: f32[8] @ DRAM
+    bar(y[0:8], x[0:8], 1 - n + m)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -2082,6 +2082,66 @@ def test_unify9(golden):
     assert str(simplify(foo)) == golden
 
 
+def test_unify10(golden):
+    @proc
+    def bar(dst: [f32][8], src: [f32][8], bound: size):
+        for i in seq(0, 8):
+            if i < bound:
+                dst[i] = src[i]
+
+    @proc
+    def foo(n: size, m: size, x: f32[n]):
+        assert n - m >= 1
+        assert n - m <= 8
+        y: f32[8]
+        for i in seq(0, 8):
+            if i + m <= n:
+                y[i] = x[i]
+
+    foo = replace(foo, foo.find_loop("i"), bar)
+    assert str(simplify(foo)) == golden
+
+
+def test_unify11(golden):
+    @proc
+    def bar(dst: [f32][8], src: [f32][8], bound: size):
+        for i in seq(0, 8):
+            if i < bound:
+                dst[i] = src[i]
+
+    @proc
+    def foo(n: size, m: size, x: f32[n]):
+        assert n - m >= 1
+        assert n - m <= 8
+        y: f32[8]
+        for i in seq(0, 8):
+            if m > n + i:
+                y[i] = x[i]
+
+    foo = replace(foo, foo.find_loop("i"), bar)
+    assert str(simplify(foo)) == golden
+
+
+def test_unify12(golden):
+    @proc
+    def bar(dst: [f32][8], src: [f32][8], bound: size):
+        for i in seq(0, 8):
+            if i < bound:
+                dst[i] = src[i]
+
+    @proc
+    def foo(n: size, m: size, x: f32[n]):
+        assert n - m >= 1
+        assert n - m <= 8
+        y: f32[8]
+        for i in seq(0, 8):
+            if m >= n + i:
+                y[i] = x[i]
+
+    foo = replace(foo, foo.find_loop("i"), bar)
+    assert str(simplify(foo)) == golden
+
+
 def test_inline_window(golden):
     @proc
     def foo(n: size, m: size, x: R[n, m]):


### PR DESCRIPTION
* Since index inequalities are operating on integers, we can simply rewrite all of them from the form: `lhs op rhs` to `0 < expr`. Then, we can perform unification on the two resulting expressions. This will allow for more unification oppurtunities.
* We have previously implemented a subcase of this, but required the two operations to be the same. This commit generalizes this idea to unify two inequalities of arbitrary ops against each other. Equalities can still only be unified if the other operation is also an equality.