### PR TITLE
Only run CI for main push or PR

### DIFF
--- a/.github/workflows/blas.yml
+++ b/.github/workflows/blas.yml
@@ -1,6 +1,9 @@
 name: BLAS
 on:
   push:
+    branches:
+      - main
+  pull_request:
 jobs:
   testing:
     strategy:

--- a/.github/workflows/blas.yml
+++ b/.github/workflows/blas.yml
@@ -20,11 +20,13 @@ jobs:
             CXX: clang++ # This will be system AppleClang
             CLANG: /usr/local/opt/llvm/bin/clang
             PRESET: apple-silicon
+            CMAKE_PREFIX_PATH: /Users/runner/work/exo/exo/benchmark/build
     env:
       CC: ${{matrix.CC}}
       CXX: ${{matrix.CXX}}
       BUILD_TYPE: Release
       CTEST_OUTPUT_ON_FAILURE: 1
+      CMAKE_PREFIX_PATH: ${{matrix.CMAKE_PREFIX_PATH}}
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout sources (including submodules)

--- a/.github/workflows/blas.yml
+++ b/.github/workflows/blas.yml
@@ -20,13 +20,11 @@ jobs:
             CXX: clang++ # This will be system AppleClang
             CLANG: /usr/local/opt/llvm/bin/clang
             PRESET: apple-silicon
-            CMAKE_PREFIX_PATH: /Users/runner/work/exo/exo/benchmark/build
     env:
       CC: ${{matrix.CC}}
       CXX: ${{matrix.CXX}}
       BUILD_TYPE: Release
       CTEST_OUTPUT_ON_FAILURE: 1
-      CMAKE_PREFIX_PATH: ${{matrix.CMAKE_PREFIX_PATH}}
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout sources (including submodules)


### PR DESCRIPTION
It was running BLAS CI for pushes to all the branches, which I suspect caused the increase in the github CI usage