### PR TITLE
Accept API types as arguments to primitives

### DIFF
--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -11,6 +11,7 @@ from .API import Procedure
 import exo.API_cursors as PC
 from .LoopIR import LoopIR, T
 import exo.LoopIR_scheduling as scheduling
+from .API_types import ExoType
 
 from .LoopIR_unification import DoReplace, UnificationError
 from .configs import Config
@@ -312,13 +313,21 @@ class EnumA(ArgumentProcessor):
 class TypeAbbrevA(ArgumentProcessor):
     _shorthand = {
         "R": T.R,
+        ExoType.R: T.R,
         "f16": T.f16,
+        ExoType.F16: T.f16,
         "f32": T.f32,
+        ExoType.F32: T.f32,
         "f64": T.f64,
+        ExoType.F64: T.f64,
         "i8": T.int8,
+        ExoType.I8: T.i8,
         "ui8": T.uint8,
+        ExoType.UI8: T.uint8,
         "ui16": T.uint16,
+        ExoType.UI16: T.ui16,
         "i32": T.int32,
+        ExoType.I32: T.i32,
     }
 
     def __call__(self, typ, all_args):

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -336,7 +336,7 @@ class TypeAbbrevA(ArgumentProcessor):
                 f"expected an instance of {ExoType} or {str} specifying the precision",
                 TypeError,
             )
-        assert not isinstance(typ, ExoType) or typ in _shorthand
+        assert not isinstance(typ, ExoType) or typ in TypeAbbrevA._shorthand
         if typ in TypeAbbrevA._shorthand:
             return TypeAbbrevA._shorthand[typ]
         else:

--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -331,12 +331,20 @@ class TypeAbbrevA(ArgumentProcessor):
     }
 
     def __call__(self, typ, all_args):
+        if not isinstance(typ, (str, ExoType)):
+            self.err(
+                f"expected an instance of {ExoType} or {str} specifying the precision",
+                TypeError,
+            )
+        assert not isinstance(typ, ExoType) or typ in _shorthand
         if typ in TypeAbbrevA._shorthand:
             return TypeAbbrevA._shorthand[typ]
         else:
-            precisions = ", ".join([t for t in TypeAbbrevA._shorthand])
+            precisions = ", ".join(
+                [t for t in TypeAbbrevA._shorthand if type(t) is str]
+            )
             self.err(
-                f"expected one of the following strings specifying "
+                f"expected an instance of {ExoType} or one of the following strings specifying "
                 f"precision: {precisions}",
                 ValueError,
             )

--- a/src/exo/API_types.py
+++ b/src/exo/API_types.py
@@ -6,9 +6,12 @@ class ProcedureBase:
 
 
 class ExoType(Enum):
+    F16 = auto()
     F32 = auto()
     F64 = auto()
+    UI8 = auto()
     I8 = auto()
+    UI16 = auto()
     I32 = auto()
     R = auto()
     Index = auto()
@@ -20,7 +23,16 @@ class ExoType(Enum):
         return self in [ExoType.Index, ExoType.Size, ExoType.Int]
 
     def is_numeric(self):
-        return self in [ExoType.F32, ExoType.F64, ExoType.I8, ExoType.I32, ExoType.R]
+        return self in [
+            ExoType.F16,
+            ExoType.F32,
+            ExoType.F64,
+            ExoType.I8,
+            ExoType.UI8,
+            ExoType.UI16,
+            ExoType.I32,
+            ExoType.R,
+        ]
 
     def is_bool(self):
         return self == ExoType.Bool

--- a/tests/golden/test_schedules/test_set_precision_api_type.txt
+++ b/tests/golden/test_schedules/test_set_precision_api_type.txt
@@ -1,0 +1,2 @@
+def bar(n: size, x: f32[n] @ DRAM):
+    pass

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1792,6 +1792,30 @@ def test_set_precision_api_type(golden):
     assert str(bar) == golden
 
 
+def test_set_precision_illegal_precision_value():
+    @proc
+    def bar(n: size, x: R[n]):
+        pass
+
+    with pytest.raises(
+        ValueError,
+        match="expected an instance of <enum 'ExoType'> or one of the following strings",
+    ):
+        bar = set_precision(bar, bar.args()[1], "Z")
+
+
+def test_set_precision_illegal_precision_type():
+    @proc
+    def bar(n: size, x: R[n]):
+        pass
+
+    with pytest.raises(
+        TypeError,
+        match="expected an instance of <enum 'ExoType'> or <class 'str'> specifying the precision",
+    ):
+        bar = set_precision(bar, bar.args()[1], bar)
+
+
 def test_rewrite_expr(golden):
     @proc
     def foo(n: size):

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -7,6 +7,7 @@ from exo import proc, DRAM, Procedure, config
 from exo.libs.memories import GEMM_SCRATCH
 from exo.stdlib.scheduling import *
 from exo.platforms.x86 import *
+from exo.API_types import *
 
 
 def test_commute(golden):
@@ -1780,6 +1781,15 @@ def test_set_precision_for_tensors_and_windows():
     )
     assert str(foo.forward(call1)._impl._node.args[1].type) == "f32[n]"
     assert str(foo.forward(call2)._impl._node.args[1].type) == "f32[n]"
+
+
+def test_set_precision_api_type(golden):
+    @proc
+    def bar(n: size, x: R[n]):
+        pass
+
+    bar = set_precision(bar, bar.args()[1], ExoType.F32)
+    assert str(bar) == golden
 
 
 def test_rewrite_expr(golden):


### PR DESCRIPTION
* Type-coerse the API types to the internal types.
* Add missing internal data types to the API types.