### PR TITLE
Cleaning up Halide scheduling implementation

### DIFF
--- a/apps/x86/halide/blur/blur.py
+++ b/apps/x86/halide/blur/blur.py
@@ -10,23 +10,6 @@ from exo.stdlib.inspection import get_enclosing_loop_by_name
 from exo.stdlib.stdlib import vectorize, is_div, is_literal
 
 
-def halide_tile(p, buffer, y, x, yi, xi, yTile, xTile):
-    assign = p.find(f"{buffer} = _")
-    y_loop = get_enclosing_loop_by_name(p, assign, y)
-    x_loop = get_enclosing_loop_by_name(p, assign, x)
-
-    return tile(p, y_loop, x_loop, [y, yi], [x, xi], yTile, xTile, perfect=True)
-
-
-def halide_compute_at(p, producer: str, consumer: str, loop: str):
-    x_loop = get_enclosing_loop_by_name(p, p.find(f"{consumer} = _"), loop)
-    return compute_at(p, producer, consumer, x_loop)
-
-
-def halide_parallel(p, loop: str):
-    return parallelize_loop(p, p.find_loop(loop))
-
-
 avx_ui16_insts = [
     mm256_loadu_si256,
     mm256_storeu_si256,
@@ -45,15 +28,28 @@ def divide_by_3_rule(proc, expr):
 def halide_vectorize(p, buffer: str, loop: str, width: int):
     loop = get_enclosing_loop_by_name(p, p.find(f"{buffer} = _"), loop)
     rules = [divide_by_3_rule]
+
+    # Ensure that it is the innermost loop
+    while len(loop.body()) == 1 and isinstance(loop.body()[0], ForCursor):
+        p = reorder_loops(p, loop)
+        loop = p.forward(loop)
+
     p = vectorize(
-        p, loop, width, "ui16", AVX2, avx_ui16_insts, rules=rules, tail="perfect"
+        p,
+        loop,
+        width,
+        "ui16",
+        AVX2,
+        avx_ui16_insts,
+        rules=[divide_by_3_rule],
+        tail="perfect",
     )
 
     return p
 
 
 @proc
-def blur(W: size, H: size, blur_y: ui16[H, W], inp: ui16[H + 2, W + 2]):
+def exo_base_blur(W: size, H: size, blur_y: ui16[H, W], inp: ui16[H + 2, W + 2]):
     assert H % 32 == 0
     assert W % 256 == 0
 
@@ -66,18 +62,16 @@ def blur(W: size, H: size, blur_y: ui16[H, W], inp: ui16[H + 2, W + 2]):
             blur_y[y, x] = (blur_x[y, x] + blur_x[y + 1, x] + blur_x[y + 2, x]) / 3.0
 
 
-def prod_halide(p):
+def halide_schedule(p):
     p = halide_tile(p, "blur_y", "y", "x", "yi", "xi", 32, 256)
-    p = halide_compute_at(p, "blur_x", "blur_y", "x")
+    p = halide_compute_and_store_at(p, "blur_x", "blur_y", "x")
     p = halide_parallel(p, "y")
     p = halide_vectorize(p, "blur_x", "xi", 16)
     p = halide_vectorize(p, "blur_y", "xi", 16)
-    p = set_memory(p, p.find(f"blur_x : _"), DRAM_STACK)
-    p = simplify(
-        p
-    )  # necessary because unification is not deterministic, which breaks test cases
+    p = set_memory(p, p.find("blur_x : _"), DRAM_STACK)
+    p = simplify(p)  # necessary because unification is not deterministic
     return p
 
 
-blur_halide = rename(prod_halide(blur), "exo_blur_halide")
-print(blur_halide)
+exo_blur = rename(halide_schedule(exo_base_blur), "exo_blur_halide")
+print(exo_blur)

--- a/apps/x86/halide/blur/blur.py
+++ b/apps/x86/halide/blur/blur.py
@@ -27,7 +27,6 @@ def divide_by_3_rule(proc, expr):
 
 def halide_vectorize(p, buffer: str, loop: str, width: int):
     loop = get_enclosing_loop_by_name(p, p.find(f"{buffer} = _"), loop)
-    rules = [divide_by_3_rule]
 
     # Ensure that it is the innermost loop
     while len(loop.body()) == 1 and isinstance(loop.body()[0], ForCursor):

--- a/apps/x86/halide/blur/blur/blur.c
+++ b/apps/x86/halide/blur/blur/blur.c
@@ -1,0 +1,130 @@
+#include "blur.h"
+
+#include <immintrin.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* relying on the following instruction..."
+avx2_ui16_divide_by_3(out,x)
+
+    {{
+        {out_data} = _mm256_mulhi_epu16({x_data}, _mm256_set1_epi16(43691));
+        {out_data} = _mm256_srli_epi16({out_data}, 1);
+    }}
+
+*/
+// exo_base_blur(
+//     W : size,
+//     H : size,
+//     blur_y : ui16[H, W] @DRAM,
+//     inp : ui16[H + 2, W + 2] @DRAM
+// )
+void exo_base_blur(void *ctxt, int_fast32_t W, int_fast32_t H, uint16_t *blur_y,
+    const uint16_t *inp) {
+  EXO_ASSUME(H % 32 == 0);
+  EXO_ASSUME(W % 256 == 0);
+  uint16_t *blur_x = (uint16_t *)malloc((H + 2) * W * sizeof(*blur_x));
+  for (int_fast32_t y = 0; y < H + 2; y++) {
+    for (int_fast32_t x = 0; x < W; x++) {
+      blur_x[y * W + x] = (inp[y * (W + 2) + x] + inp[y * (W + 2) + x + 1] +
+                              inp[y * (W + 2) + x + 2]) /
+                          ((uint16_t)3.0);
+    }
+  }
+  for (int_fast32_t y = 0; y < H; y++) {
+    for (int_fast32_t x = 0; x < W; x++) {
+      blur_y[y * W + x] = (blur_x[y * W + x] + blur_x[(y + 1) * W + x] +
+                              blur_x[(y + 2) * W + x]) /
+                          ((uint16_t)3.0);
+    }
+  }
+  free(blur_x);
+}
+
+// exo_blur_halide(
+//     W : size,
+//     H : size,
+//     blur_y : ui16[H, W] @DRAM,
+//     inp : ui16[H + 2, W + 2] @DRAM
+// )
+void exo_blur_halide(void *ctxt, int_fast32_t W, int_fast32_t H,
+    uint16_t *blur_y, const uint16_t *inp) {
+  EXO_ASSUME(H % 32 == 0);
+  EXO_ASSUME(W % 256 == 0);
+#pragma omp parallel for
+  for (int_fast32_t y = 0; y < ((H) / (32)); y++) {
+    for (int_fast32_t x = 0; x < ((W) / (256)); x++) {
+      uint16_t blur_x[34 * 256];
+      for (int_fast32_t yi = 0; yi < 34; yi++) {
+        for (int_fast32_t xio = 0; xio < 16; xio++) {
+          __m256i var0;
+          __m256i var1;
+          __m256i var2;
+          __m256i var3;
+          __m256i var4;
+          __m256i var5;
+          var3 = _mm256_loadu_si256((const __m256i
+                  *)&inp[(yi + 32 * y) * (W + 2) + 16 * xio + 256 * x]);
+          var4 = _mm256_loadu_si256((const __m256i
+                  *)&inp[(yi + 32 * y) * (W + 2) + 1 + 16 * xio + 256 * x]);
+          var2 = _mm256_adds_epu16(var3, var4);
+          var5 = _mm256_loadu_si256((const __m256i
+                  *)&inp[(yi + 32 * y) * (W + 2) + 2 + 16 * xio + 256 * x]);
+          var1 = _mm256_adds_epu16(var2, var5);
+
+          {
+            var0 = _mm256_mulhi_epu16(var1, _mm256_set1_epi16(43691));
+            var0 = _mm256_srli_epi16(var0, 1);
+          }
+
+          _mm256_storeu_si256(
+              (__m256i *)&blur_x[(yi) * (256) + 16 * xio], var0);
+        }
+      }
+      for (int_fast32_t yi = 0; yi < 32; yi++) {
+        for (int_fast32_t xio = 0; xio < 16; xio++) {
+          __m256i var6;
+          __m256i var7;
+          __m256i var8;
+          __m256i var9;
+          __m256i var10;
+          __m256i var11;
+          var9 = _mm256_loadu_si256(
+              (const __m256i *)&blur_x[(yi) * (256) + 16 * xio]);
+          var10 = _mm256_loadu_si256(
+              (const __m256i *)&blur_x[(1 + yi) * (256) + 16 * xio]);
+          var8 = _mm256_adds_epu16(var9, var10);
+          var11 = _mm256_loadu_si256(
+              (const __m256i *)&blur_x[(2 + yi) * (256) + 16 * xio]);
+          var7 = _mm256_adds_epu16(var8, var11);
+
+          {
+            var6 = _mm256_mulhi_epu16(var7, _mm256_set1_epi16(43691));
+            var6 = _mm256_srli_epi16(var6, 1);
+          }
+
+          _mm256_storeu_si256(
+              (__m256i *)&blur_y[(yi + 32 * y) * W + 16 * xio + 256 * x], var6);
+        }
+      }
+    }
+  }
+}
+
+/* relying on the following instruction..."
+mm256_add_epi16(out,x,y)
+{out_data} = _mm256_adds_epu16({x_data}, {y_data});
+*/
+
+/* relying on the following instruction..."
+mm256_loadu_si256(dst,src)
+{dst_data} = _mm256_loadu_si256((const __m256i *) &{src_data});
+*/
+
+/* relying on the following instruction..."
+mm256_storeu_si256(dst,src)
+_mm256_storeu_si256((__m256i *) &{dst_data}, {src_data});
+*/

--- a/apps/x86/halide/blur/blur/blur.h
+++ b/apps/x86/halide/blur/blur/blur.h
@@ -1,0 +1,59 @@
+
+#pragma once
+#ifndef BLUR_H
+#define BLUR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Compiler feature macros adapted from Hedley (public domain)
+// https://github.com/nemequ/hedley
+
+#if defined(__has_builtin)
+#define EXO_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+#define EXO_HAS_BUILTIN(builtin) (0)
+#endif
+
+#if EXO_HAS_BUILTIN(__builtin_assume)
+#define EXO_ASSUME(expr) __builtin_assume(expr)
+#elif EXO_HAS_BUILTIN(__builtin_unreachable)
+#define EXO_ASSUME(expr) ((void)((expr) ? 1 : (__builtin_unreachable(), 1)))
+#else
+#define EXO_ASSUME(expr) ((void)(expr))
+#endif
+
+struct exo_win_1ui16 {
+  uint16_t *const data;
+  const int_fast32_t strides[1];
+};
+struct exo_win_1ui16c {
+  const uint16_t *const data;
+  const int_fast32_t strides[1];
+};
+// exo_base_blur(
+//     W : size,
+//     H : size,
+//     blur_y : ui16[H, W] @DRAM,
+//     inp : ui16[H + 2, W + 2] @DRAM
+// )
+void exo_base_blur(void *ctxt, int_fast32_t W, int_fast32_t H, uint16_t *blur_y,
+    const uint16_t *inp);
+
+// exo_blur_halide(
+//     W : size,
+//     H : size,
+//     blur_y : ui16[H, W] @DRAM,
+//     inp : ui16[H + 2, W + 2] @DRAM
+// )
+void exo_blur_halide(void *ctxt, int_fast32_t W, int_fast32_t H,
+    uint16_t *blur_y, const uint16_t *inp);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // BLUR_H

--- a/src/exo/stdlib/halide_scheduling_ops.py
+++ b/src/exo/stdlib/halide_scheduling_ops.py
@@ -29,7 +29,7 @@ def get_affected_dim(proc, buffer_name: str, iter_sym) -> list[int]:
     return list(dims)[0]
 
 
-def fuse_at(proc, producer: str, consumer: str, target_loop):
+def compute_at(proc: Procedure, producer_assign: AssignCursor, target_loop: ForCursor):
     """
     Computes the necessary values of producer at the level of [target_loop]
     in the consumer loop nest by fusing the two loop nests.
@@ -37,9 +37,9 @@ def fuse_at(proc, producer: str, consumer: str, target_loop):
     Example transformation:
         for i in _:
             for j in _:
-                producer[_] = ...
+                producer[_] = ... # producer_assign
         for io in _:
-            for jo in _:
+            for jo in _: # target_loop
                 for ii in _:
                     for ji in _:
                         consumer[_] = ...
@@ -56,38 +56,45 @@ def fuse_at(proc, producer: str, consumer: str, target_loop):
     TODO: add returning relevant cursors
     """
 
+    producer_assign = proc.forward(producer_assign)
     target_loop = proc.forward(target_loop)
-    p_assign = proc.find(f"{producer}[_] = _")
-    p_loop = get_top_level_stmt(proc, p_assign)
+
+    producer = producer_assign.name()
+    p_loop = get_top_level_stmt(proc, producer_assign)
     c_loops = [target_loop] + list(get_parents(proc, target_loop, up_to=None))
 
     assert p_loop.next() == c_loops[-1], "loop nests must be consecutive"
 
     for c_loop in reversed(c_loops):
         c_loop = proc.forward(c_loop)
-        p_loop = get_enclosing_loop_by_name(proc, proc.forward(p_assign), c_loop.name())
-        assert p_loop.next() == c_loop
+        p_loop = get_enclosing_loop_by_name(
+            proc, proc.forward(producer_assign), c_loop.name()
+        )
 
-        # infer bounds of consumer to determine cut-factor
-        N_c = c_loop.hi()._impl._node
-        buffer_dim = get_affected_dim(proc, consumer, c_loop.name())
-        w_c = bounds_inference(proc, c_loop, consumer, buffer_dim).get_size()
+        # Reorder producer loop up to consumer loop level and adjacent
+        while p_loop.parent() != c_loop.parent():
+            proc = reorder_loops(proc, p_loop.parent())
+            p_loop = proc.forward(p_loop)
+            c_loop = proc.forward(c_loop)
+        while p_loop.next() != c_loop:
+            proc = reorder_stmts(proc, p_loop.expand(0, 1))
+            p_loop = proc.forward(p_loop)
+            c_loop = proc.forward(c_loop)
+
+        # Infer bounds of producer that the are consumed to determine cut-factor
+        N_c = c_loop.hi()._impl._node  # TODO: remove this ._impl._node
+        buffer_dim = get_affected_dim(proc, producer, c_loop.name())
+        bounds = bounds_inference(proc, c_loop, producer, buffer_dim, include=["R"])
+        w_c = bounds.get_stride_of(c_loop._impl._node.iter)
 
         p_iter = p_loop.name()
         new_iters = [f"{p_iter}", f"{p_iter}i"]
-
         proc = divide_with_recompute(proc, p_loop, f"{N_c}", w_c, new_iters)
         proc = fuse(proc, p_loop, c_loop, unsafe_disable_check=True)
 
-        # TODO: rethink the reorder thing here
-        p_inner_loop = proc.forward(p_loop).body()[0]
-        while isinstance(p_inner_loop.body()[0], ForCursor):
-            proc = reorder_loops(proc, p_inner_loop)
-            p_inner_loop = proc.forward(p_inner_loop)
-
         # TODO: Try to simplify the expressions without needing this.
         # This would also remove the need for the LoopIR import.
-        for pred in p_assign._impl.get_root().preds:
+        for pred in proc._loopir_proc.preds:
             if (
                 isinstance(pred, LoopIR.BinOp)
                 and pred.op == "=="
@@ -102,13 +109,15 @@ def fuse_at(proc, producer: str, consumer: str, target_loop):
     return simplify(proc)
 
 
-def store_at(proc, producer, target_loop):
+def store_at(proc: Procedure, producer_alloc: AllocCursor, target_loop: ForCursor):
     """
     Moves [producer]'s allocation into [target_loop] and reduces the dimensions
     as necessary.
     """
+    producer_alloc = proc.forward(producer_alloc)
     target_loop = proc.forward(target_loop)
-    producer_alloc = proc.find(f"{producer}:_")
+
+    producer = producer_alloc.name()
 
     def loops_between(producer_alloc, target_loop):
         """
@@ -133,10 +142,10 @@ def store_at(proc, producer, target_loop):
         lo, _ = bounds.get_bounds()
         size = bounds.get_size()
 
-        # TODO: think more about this reorder strategy
         while producer_alloc.next() != loop:
-            reorder_stmts(proc, producer_alloc.expand(0, 1))
+            proc = reorder_stmts(proc, producer_alloc.expand(0, 1))
             producer_alloc = proc.forward(producer_alloc)
+            loop = proc.forward(loop)
 
         proc = sink_alloc(proc, producer_alloc)
         proc = resize_dim(proc, producer_alloc, buffer_dim, size, lo)
@@ -144,31 +153,41 @@ def store_at(proc, producer, target_loop):
     return simplify(proc)
 
 
-def compute_at(proc, producer, consumer, target_loop):
+def compute_and_store_at(proc: Procedure, producer: str, target_loop: ForCursor):
     """
-    Halide's compute_at is a combination of fuse_at and store_at.
+    Calling Halide's compute_at without a corresponding store_at is implicitly a combination
+    of compute_at and store_at.
+    Args:
+        producer/consumer   - name of the buffers for the producer/consumer stages
+        target_loop         - loop level to compute at
     """
     target_loop = proc.forward(target_loop)
-    proc = fuse_at(proc, producer, consumer, target_loop)
+    producer_assign = proc.find(f"{producer} = _")
+    proc = compute_at(proc, producer_assign, target_loop)
 
+    producer_alloc = proc.find(f"{producer} : _")
     target_loop = proc.forward(target_loop.body()[0]).parent()
-    proc = store_at(proc, producer, target_loop)
+    proc = store_at(proc, producer_alloc, target_loop)
 
     return proc
 
 
 def tile(
-    proc,
-    i_loop,
-    j_loop,
-    new_i_iters,
-    new_j_iters,
-    i_tile_size,
-    j_tile_size,
-    perfect=True,
+    proc: Procedure,
+    i_loop: ForCursor,
+    j_loop: ForCursor,
+    new_i_iters: list[str],
+    new_j_iters: list[str],
+    i_tile_size: int,
+    j_tile_size: int,
+    perfect: bool = True,
 ):
     assert j_loop.parent() == i_loop
-    assert perfect, "only perfect tiling is supported"
+    assert perfect, "only perfect tiling is currently supported"
+
+    i_loop = proc.forward(i_loop)
+    j_loop = proc.forward(j_loop)
+
     proc = divide_loop(proc, i_loop, i_tile_size, new_i_iters, perfect=perfect)
     proc = divide_loop(proc, j_loop, j_tile_size, new_j_iters, perfect=perfect)
     ii_loop = proc.forward(i_loop).body()[0]
@@ -176,9 +195,53 @@ def tile(
     return proc
 
 
+def halide_tile(p, buffer, y, x, yi, xi, yTile, xTile):
+    assign = p.find(f"{buffer} = _")
+    y_loop = get_enclosing_loop_by_name(p, assign, y)
+    x_loop = get_enclosing_loop_by_name(p, assign, x)
+
+    return tile(p, y_loop, x_loop, [y, yi], [x, xi], yTile, xTile, perfect=True)
+
+
+def halide_split(
+    p, stage: str, x: str, xo: str, xi: str, split_factor: int, tail: str = "perfect"
+):
+    """
+    tail can be {"perfect", "cut", "guard", "cut_and_guard"}
+    """
+    loop = get_enclosing_loop_by_name(p, p.find(f"{stage} = _"), x)
+    return split(p, loop, xo, xi, split_factor, tail)
+
+
+def halide_compute_at(p, producer: str, consumer: str, loop: str):
+    producer_assign = p.find(f"{producer} = _")
+    target_loop = get_enclosing_loop_by_name(p, p.find(f"{consumer} = _"), loop)
+    return compute_at(p, producer_assign, target_loop)
+
+
+def halide_store_at(p, producer: str, consumer: str, loop: str):
+    target_loop = get_enclosing_loop_by_name(p, p.find(f"{consumer} = _"), loop)
+    producer_alloc = p.find(f"{producer} : _")
+    return store_at(p, producer_alloc, target_loop)
+
+
+def halide_compute_and_store_at(p, producer: str, consumer: str, loop: str):
+    target_loop = get_enclosing_loop_by_name(p, p.find(f"{consumer} = _"), loop)
+    return compute_and_store_at(p, producer, target_loop)
+
+
+def halide_parallel(p, loop: str):
+    return parallelize_loop(p, p.find_loop(loop))
+
+
 __all__ = [
-    "fuse_at",
-    "store_at",
     "compute_at",
+    "store_at",
+    "compute_and_store_at",
     "tile",
+    "halide_tile",
+    "halide_compute_at",
+    "halide_store_at",
+    "halide_compute_and_store_at",
+    "halide_parallel",
 ]

--- a/tests/golden/test_apps/test_blur.txt
+++ b/tests/golden/test_apps/test_blur.txt
@@ -38,13 +38,13 @@ struct exo_win_1ui16c{
     const uint16_t * const data;
     const int_fast32_t strides[1];
 };
-// blur(
+// exo_base_blur(
 //     W : size,
 //     H : size,
 //     blur_y : ui16[H, W] @DRAM,
 //     inp : ui16[H + 2, W + 2] @DRAM
 // )
-void blur( void *ctxt, int_fast32_t W, int_fast32_t H, uint16_t* blur_y, const uint16_t* inp );
+void exo_base_blur( void *ctxt, int_fast32_t W, int_fast32_t H, uint16_t* blur_y, const uint16_t* inp );
 
 // exo_blur_halide(
 //     W : size,
@@ -84,13 +84,13 @@ avx2_ui16_divide_by_3(out,x)
     }}
     
 */
-// blur(
+// exo_base_blur(
 //     W : size,
 //     H : size,
 //     blur_y : ui16[H, W] @DRAM,
 //     inp : ui16[H + 2, W + 2] @DRAM
 // )
-void blur( void *ctxt, int_fast32_t W, int_fast32_t H, uint16_t* blur_y, const uint16_t* inp ) {
+void exo_base_blur( void *ctxt, int_fast32_t W, int_fast32_t H, uint16_t* blur_y, const uint16_t* inp ) {
 EXO_ASSUME(H % 32 == 0);
 EXO_ASSUME(W % 256 == 0);
 uint16_t *blur_x = (uint16_t*) malloc((H + 2) * W * sizeof(*blur_x));

--- a/tests/golden/test_halide_ops/test_schedule_blur2d.txt
+++ b/tests/golden/test_halide_ops/test_schedule_blur2d.txt
@@ -3,8 +3,8 @@ def blur2d_compute_at_i_store_root(n: size, consumer: i8[n, n] @ DRAM,
     assert n % 4 == 0
     producer: i8[1 + n, 1 + n] @ DRAM
     for i in seq(0, n):
-        for j in seq(0, 1 + n):
-            for ii in seq(0, 2):
+        for ii in seq(0, 2):
+            for j in seq(0, 1 + n):
                 producer[i + ii, j] = sin[i + ii, j]
         for j in seq(0, n):
             consumer[i,
@@ -17,8 +17,8 @@ def blur2d_compute_at_j_store_root(n: size, consumer: i8[n, n] @ DRAM,
     producer: i8[1 + n, 1 + n] @ DRAM
     for i in seq(0, n):
         for j in seq(0, n):
-            for ii in seq(0, 2):
-                for ji in seq(0, 2):
+            for ji in seq(0, 2):
+                for ii in seq(0, 2):
                     producer[i + ii, j + ji] = sin[i + ii, j + ji]
             consumer[i,
                      j] = (producer[i, j] + producer[i, 1 + j] +
@@ -29,8 +29,8 @@ def blur2d_compute_at_i(n: size, consumer: i8[n, n] @ DRAM,
     assert n % 4 == 0
     for i in seq(0, n):
         producer: i8[2, 1 + n] @ DRAM
-        for j in seq(0, 1 + n):
-            for ii in seq(0, 2):
+        for ii in seq(0, 2):
+            for j in seq(0, 1 + n):
                 producer[ii, j] = sin[i + ii, j]
         for j in seq(0, n):
             consumer[i, j] = (producer[0, j] + producer[0, 1 + j] +
@@ -42,8 +42,8 @@ def blur2d_compute_at_j_store_at_i(n: size, consumer: i8[n, n] @ DRAM,
     for i in seq(0, n):
         producer: i8[2, 1 + n] @ DRAM
         for j in seq(0, n):
-            for ii in seq(0, 2):
-                for ji in seq(0, 2):
+            for ji in seq(0, 2):
+                for ii in seq(0, 2):
                     producer[ii, j + ji] = sin[i + ii, j + ji]
             consumer[i, j] = (producer[0, j] + producer[0, 1 + j] +
                               producer[1, j] + producer[1, 1 + j]) / 4.0

--- a/tests/golden/test_halide_ops/test_schedule_tiled_blur2d.txt
+++ b/tests/golden/test_halide_ops/test_schedule_tiled_blur2d.txt
@@ -21,8 +21,8 @@ def blur2d_tiled_compute_at_i(n: size, consumer: i8[n, n] @ DRAM,
     assert n % 4 == 0
     producer: i8[1 + n, 1 + n] @ DRAM
     for i in seq(0, n / 4):
-        for j in seq(0, 1 + n):
-            for ii in seq(0, 5):
+        for ii in seq(0, 5):
+            for j in seq(0, 1 + n):
                 producer[ii + 4 * i, j] = sin[ii + 4 * i, j]
         for j in seq(0, n / 4):
             for ii in seq(0, 4):
@@ -39,8 +39,8 @@ def blur2d_tiled_compute_at_j(n: size, consumer: i8[n, n] @ DRAM,
     producer: i8[1 + n, 1 + n] @ DRAM
     for i in seq(0, n / 4):
         for j in seq(0, n / 4):
-            for ii in seq(0, 5):
-                for ji in seq(0, 5):
+            for ji in seq(0, 5):
+                for ii in seq(0, 5):
                     producer[ii + 4 * i, ji + 4 * j] = sin[ii + 4 * i,
                                                            ji + 4 * j]
             for ii in seq(0, 4):
@@ -58,8 +58,8 @@ def blur2d_tiled_compute_at_ii(n: size, consumer: i8[n, n] @ DRAM,
     for i in seq(0, n / 4):
         for j in seq(0, n / 4):
             for ii in seq(0, 4):
-                for ji in seq(0, 5):
-                    for iii in seq(0, 2):
+                for iii in seq(0, 2):
+                    for ji in seq(0, 5):
                         producer[ii + iii + 4 * i,
                                  ji + 4 * j] = sin[ii + iii + 4 * i,
                                                    ji + 4 * j]
@@ -78,8 +78,8 @@ def blur2d_tiled_compute_at_ji(n: size, consumer: i8[n, n] @ DRAM,
         for j in seq(0, n / 4):
             for ii in seq(0, 4):
                 for ji in seq(0, 4):
-                    for iii in seq(0, 2):
-                        for jii in seq(0, 2):
+                    for jii in seq(0, 2):
+                        for iii in seq(0, 2):
                             producer[ii + iii + 4 * i,
                                      ji + jii + 4 * j] = sin[ii + iii + 4 * i,
                                                              ji + jii + 4 * j]
@@ -97,8 +97,8 @@ def blur2d_tiled_compute_at_and_store_at_ji(n: size, consumer: i8[n, n] @ DRAM,
             for ii in seq(0, 4):
                 for ji in seq(0, 4):
                     producer: i8[2, 2] @ DRAM
-                    for iii in seq(0, 2):
-                        for jii in seq(0, 2):
+                    for jii in seq(0, 2):
+                        for iii in seq(0, 2):
                             producer[iii, jii] = sin[ii + iii + 4 * i,
                                                      ji + jii + 4 * j]
                     consumer[ii + 4 * i, ji +

--- a/tests/test_halide_ops.py
+++ b/tests/test_halide_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 
 from exo import proc
 from exo.platforms.x86 import *
@@ -25,13 +26,14 @@ def test_schedule_blur1d(golden):
     procs = []
 
     loop = p.find_loop("i #1")
-    p = fuse_at(p, "producer", "consumer", loop)
+    producer_assign = p.find("producer = _")
+    p = compute_at(p, producer_assign, loop)
     p = rename(p, "blur1d_compute_at_store_root")
     procs.append(p)
 
     loop = p.find_loop("i")
-    p_bounds = (0, "i", 0, 2)
-    p = store_at(p, "producer", loop)
+    producer_alloc = p.find("producer : _")
+    p = store_at(p, producer_alloc, loop)
     p = rename(p, "blur1d_compute_at")
     procs.append(p)
 
@@ -71,33 +73,37 @@ def test_schedule_blur2d(golden):
     p = blur2d_compute_root
     procs = []
 
-    p = fuse_at(p, "producer", "consumer", p.find_loop("i #1"))
+    producer_assign = p.find("producer = _")
+    producer_alloc = p.find("producer : _")
+
+    p = compute_at(p, producer_assign, p.find_loop("i #1"))
     p = rename(p, "blur2d_compute_at_i_store_root")
     procs.append(p)
 
     p = blur2d_compute_root
-    p = fuse_at(p, "producer", "consumer", p.find_loop("j #1"))
+    p = compute_at(p, producer_assign, p.find_loop("j #1"))
     p = rename(p, "blur2d_compute_at_j_store_root")
     procs.append(p)
 
     p = blur2d_compute_root
-    p = fuse_at(p, "producer", "consumer", p.find_loop("i #1"))
-    p = store_at(p, "producer", p.find_loop("i"))
+    p = compute_at(p, producer_assign, p.find_loop("i #1"))
+    p = store_at(p, producer_alloc, p.find_loop("i"))
     p = rename(p, "blur2d_compute_at_i")
     procs.append(p)
 
     p = blur2d_compute_root
-    p = fuse_at(p, "producer", "consumer", p.find_loop("j #1"))
-    p = store_at(p, "producer", p.find_loop("i"))
+    p = compute_at(p, producer_assign, p.find_loop("j #1"))
+    p = store_at(p, producer_alloc, p.find_loop("i"))
     p = simplify(p)
     p = rename(p, "blur2d_compute_at_j_store_at_i")
     procs.append(p)
 
     p = blur2d_compute_root
-    p = fuse_at(p, "producer", "consumer", p.find_loop("j #1"))
-    p = store_at(p, "producer", p.find_loop("j"))
-    p = unroll_loop(p, "ji")
+    p = compute_at(p, producer_assign, p.find_loop("j #1"))
+    p = store_at(p, producer_alloc, p.find_loop("j"))
     p = unroll_loop(p, "ii")
+    p = unroll_loop(p, "ji")
+    print(p)
     for i in range(4):
         p = inline_assign(p, p.find("consumer[_] = _").prev())
     p = delete_buffer(p, "producer: _")
@@ -107,6 +113,7 @@ def test_schedule_blur2d(golden):
     assert "\n\n".join([str(p) for p in procs]) == golden
 
 
+@pytest.mark.slow
 def test_schedule_tiled_blur2d(golden):
     compute_root = blur2d_compute_root
     procs = []
@@ -122,33 +129,36 @@ def test_schedule_tiled_blur2d(golden):
         perfect=True,
     )
 
+    producer_assign = p_tiled.find("producer = _")
+    producer_alloc = p_tiled.find("producer : _")
+
     p = p_tiled
     p = rename(p, "blur2d_tiled")
     procs.append(p)
 
     p = p_tiled
-    p = fuse_at(p, "producer", "consumer", p.find_loop("i #1"))
+    p = compute_at(p, producer_assign, p.find_loop("i #1"))
     p = rename(p, "blur2d_tiled_compute_at_i")
     procs.append(p)
 
     p = p_tiled
-    p = fuse_at(p, "producer", "consumer", p.find_loop("j #1"))
+    p = compute_at(p, producer_assign, p.find_loop("j #1"))
     p = rename(p, "blur2d_tiled_compute_at_j")
     procs.append(p)
 
     p = p_tiled
-    p = fuse_at(p, "producer", "consumer", p.find_loop("ii"))
+    p = compute_at(p, producer_assign, p.find_loop("ii"))
     p = rename(p, "blur2d_tiled_compute_at_ii")
     procs.append(p)
 
     p = p_tiled
-    p = fuse_at(p, "producer", "consumer", p.find_loop("ji"))
+    p = compute_at(p, producer_assign, p.find_loop("ji"))
     p = rename(p, "blur2d_tiled_compute_at_ji")
     procs.append(p)
 
     p = p_tiled
-    p = fuse_at(p, "producer", "consumer", p.find_loop("ji"))
-    p = store_at(p, "producer", p.find_loop("ji"))
+    p = compute_at(p, producer_assign, p.find_loop("ji"))
+    p = store_at(p, producer_alloc, p.find_loop("ji"))
     p = rename(p, "blur2d_tiled_compute_at_and_store_at_ji")
     procs.append(p)
 

--- a/tests/test_range_analysis.py
+++ b/tests/test_range_analysis.py
@@ -487,6 +487,7 @@ def test_bounds_inference_tiled_blur2d():
                             + producer[4 * io + ii + 1, 4 * jo + ji + 1]
                         ) / 4.0
 
+    loop = blur2d_tiled.find_loop("io")
     io_sym = loop._impl._node.iter
     bound = bounds_inference(blur2d_tiled, loop, "producer", 0, include=["R"])
     assert str(bound) == "(io * 4, 0, 4)"

--- a/tests/test_range_analysis.py
+++ b/tests/test_range_analysis.py
@@ -487,18 +487,21 @@ def test_bounds_inference_tiled_blur2d():
                             + producer[4 * io + ii + 1, 4 * jo + ji + 1]
                         ) / 4.0
 
-    loop = blur2d_tiled.find_loop("io")
+    io_sym = loop._impl._node.iter
     bound = bounds_inference(blur2d_tiled, loop, "producer", 0, include=["R"])
     assert str(bound) == "(io * 4, 0, 4)"
 
     loop = blur2d_tiled.find_loop("jo")
+    jo_sym = loop._impl._node.iter
     bound = bounds_inference(blur2d_tiled, loop, "producer", 1, include=["R"])
     assert str(bound) == "(jo * 4, 0, 4)"
 
     bound = bounds_inference(blur2d_tiled, loop, "producer", 0, include=["R"])
     assert str(bound) == "(io * 4, 0, 4)"
+    assert bound.get_stride_of(io_sym) == 4
     bound = bounds_inference(blur2d_tiled, loop, "producer", 1, include=["R"])
     assert str(bound) == "(jo * 4, 0, 4)"
+    assert bound.get_stride_of(jo_sym) == 4
 
 
 def test_bounds_inference_fail():


### PR DESCRIPTION
- Moved reusable Halide scheduling operations from `blur.py` to `halide_scheduling_ops.py`, and added types/documentation.
- Added the generated optimized `blur.c` and `blur.h` files to the repo.
- Renamed `fuse_at` and `compute_at` to `compute_at` and `compute_and_store_at`, respectively. This better matches Halide's usage of the terms.
- Cleaner implementation of loop reordering and bounds inference within `store_at` and `compute_at`.
