### PR TITLE
Fixed a few bugs in bind_expr

### DIFF
--- a/src/exo/API_scheduling.py
+++ b/src/exo/API_scheduling.py
@@ -971,10 +971,9 @@ def rewrite_expr(proc, expr_cursor, new_expr):
 def bind_expr(proc, expr_cursors, new_name):
     """
     Bind some numeric/data-value type expression(s) into a new intermediate,
-    scalar-sized buffer. Attempts to perform common sub-expression
-    elimination while binding. It will stop upon encountering a read of any
-    buffer that the expression depends on. The precision of the new allocation
-    is that of the bound expression.
+    scalar-sized buffer. It will fail if not all of the provided expressions
+    can be bound safely. The precision of the new allocation is that of the
+    bound expression.
 
     args:
         expr_cursors    - a list of cursors to multiple instances of the

--- a/src/exo/LoopIR_scheduling.py
+++ b/src/exo/LoopIR_scheduling.py
@@ -1220,6 +1220,7 @@ def get_enclosing_stmt_cursor(c):
 
 
 def less(c1, c2):
+    assert c1._root == c2._root
     p1, p2 = c1._path, c2._path
     for i in range(min(len(p1), len(p2))):
         if p1[i] < p2[i]:
@@ -1227,6 +1228,21 @@ def less(c1, c2):
         elif p1[i] > p2[i]:
             return False
     return len(p1) < len(p2)
+
+
+def match_parent(c1, c2):
+    assert c1._root == c2._root
+    root = c1._root
+
+    p1, p2 = c1._path, c2._path
+
+    i = 0
+    while i < min(len(p1), len(p2)) and p1[i] == p2[i]:
+        i += 1
+
+    c1 = ic.Node(root, p1[: i + 1])
+    c2 = ic.Node(root, p2[: i + 1])
+    return c1, c2
 
 
 def DoRewriteExpr(expr_cursor, new_expr):
@@ -1247,16 +1263,19 @@ def DoBindExpr(new_name, expr_cursors):
     # TODO: dirty hack. need real CSE-equality (i.e. modulo srcinfo)
     expr_cursors = [c for c in expr_cursors if str(c._node) == str(expr)]
 
-    init_c = get_enclosing_stmt_cursor(expr_cursors[0])
+    init_s = get_enclosing_stmt_cursor(expr_cursors[0])
+    if len(expr_cursors) > 1:
+        # TODO: Currently assume expr cursors is sorted in order
+        init_s, _ = match_parent(init_s, expr_cursors[-1])
 
     new_name = Sym(new_name)
     alloc_s = LoopIR.Alloc(new_name, expr.type.basetype(), DRAM, expr.srcinfo)
     assign_s = LoopIR.Assign(new_name, expr.type.basetype(), [], expr, expr.srcinfo)
-    ir, fwd = init_c.before()._insert([alloc_s, assign_s])
+    ir, fwd = init_s.before()._insert([alloc_s, assign_s])
 
     new_read = LoopIR.Read(new_name, [], expr.type, expr.srcinfo)
     first_write_c = None
-    for c in get_rest_of_block(init_c, inclusive=True):
+    for c in get_rest_of_block(init_s, inclusive=True):
         for block in match_pattern(c, "_ = _"):
             assert len(block) == 1
             sc = block[0]
@@ -1273,24 +1292,23 @@ def DoBindExpr(new_name, expr_cursors):
                 else:
                     first_write_c = sc
                 break
-        if first_write_c:
-            while expr_cursors and (
-                less(expr_cursors[0], first_write_c)
-                or first_write_c.is_ancestor_of(expr_cursors[0])
-            ):
-                ir, fwd_repl = _replace_helper(
-                    fwd(expr_cursors[0]), new_read, only_replace_attrs=False
-                )
-                fwd = _compose(fwd_repl, fwd)
-                expr_cursors.pop(0)
+
+        if first_write_c and isinstance(c._node, (LoopIR.For, LoopIR.If)):
+            # Potentially unsafe to partially bind, err on side of caution for now
             break
-        else:
-            while expr_cursors and c.is_ancestor_of(expr_cursors[0]):
-                ir, fwd_repl = _replace_helper(
-                    fwd(expr_cursors[0]), new_read, only_replace_attrs=False
-                )
-                fwd = _compose(fwd_repl, fwd)
-                expr_cursors.pop(0)
+
+        while expr_cursors and c.is_ancestor_of(expr_cursors[0]):
+            ir, fwd_repl = _replace_helper(
+                fwd(expr_cursors[0]), new_read, only_replace_attrs=False
+            )
+            fwd = _compose(fwd_repl, fwd)
+            expr_cursors.pop(0)
+
+        if first_write_c:
+            break
+
+    if len(expr_cursors) > 0:
+        raise SchedulingError("Unsafe to bind all of the provided exprs.")
 
     Check_Aliasing(ir)
     return ir, fwd

--- a/tests/golden/test_schedules/test_bind_expr_cse.txt
+++ b/tests/golden/test_schedules/test_bind_expr_cse.txt
@@ -1,0 +1,7 @@
+def foo(a: i8 @ DRAM, b: i8 @ DRAM, c: i8 @ DRAM):
+    two_times_a: R @ DRAM
+    two_times_a = 2.0 * a
+    b = two_times_a
+    for i in seq(0, 5):
+        c += 2.0 * a
+        a = 2.0 * a

--- a/tests/golden/test_schedules/test_bind_expr_cse_2.txt
+++ b/tests/golden/test_schedules/test_bind_expr_cse_2.txt
@@ -1,0 +1,7 @@
+def foo(x: i8[5] @ DRAM, y: i8[5] @ DRAM):
+    two: R @ DRAM
+    two = 2.0
+    for i in seq(0, 5):
+        x[i] = two
+    for i in seq(0, 5):
+        y[i] = two


### PR DESCRIPTION
Bind expr previously allowed some incorrect use cases.

Furthermore, it didn't allow use cases such as the one I added in `test_bind_expr_cse_2`, so I extended the implementation to cover that.