### PR TITLE
Distinguish type error from name error in pyparser

### DIFF
--- a/src/exo/frontend/pyparser.py
+++ b/src/exo/frontend/pyparser.py
@@ -883,8 +883,8 @@ class Parser:
                     nm = self.locals[nm_node.id]
                 elif nm_node.id in self.globals:
                     nm = self.globals[nm_node.id]
-                else:
-                    nm = None
+                else:  # could not resolve name to anything
+                    self.err(nm_node, f"variable '{nm_node.id}' undefined")
 
                 if isinstance(nm, SizeStub):
                     nm = nm.nm
@@ -899,8 +899,11 @@ class Parser:
                         )
                     else:
                         return UAST.Const(nm, self.getsrcinfo(e))
-                else:  # could not resolve name to anything
-                    self.err(nm_node, f"variable '{nm_node.id}' undefined")
+                else:
+                    self.err(
+                        nm_node,
+                        f"variable '{nm_node.id}' has unsupported type {type(nm)}",
+                    )
 
                 if is_window:
                     return UAST.WindowExpr(nm, idxs, self.getsrcinfo(e))

--- a/tests/test_uast.py
+++ b/tests/test_uast.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from exo import DRAM
-from exo.frontend.pyparser import Parser, get_src_locals, get_ast_from_python
+from exo.frontend.pyparser import (
+    Parser,
+    get_src_locals,
+    get_ast_from_python,
+    ParseError,
+)
 
 
 def to_uast(f):
@@ -10,7 +17,7 @@ def to_uast(f):
         body,
         getsrcinfo,
         func_globals=f.__globals__,
-        srclocals=get_src_locals(depth=3),
+        srclocals=get_src_locals(depth=2),
         instr=("TEST", ""),
         as_func=True,
     )
@@ -57,3 +64,58 @@ def test_alloc_nest(golden):
                 res[i, j] = rloc[j]
 
     assert str(to_uast(alloc_nest)) == golden
+
+
+global_str = "What is 6 times 9?"
+global_num = 42
+
+
+def test_variable_lookup_positive():
+    def func(f: f32):
+        for i in seq(0, 42):
+            f += 1
+
+    reference = to_uast(func)
+
+    def func(f: f32):
+        for i in seq(0, global_num):
+            f += 1
+
+    test_global = to_uast(func)
+    assert str(test_global) == str(reference)
+
+    local_num = 42
+
+    def func(f: f32):
+        for i in seq(0, local_num):
+            f += 1
+
+    test_local = to_uast(func)
+    assert str(test_local) == str(reference)
+
+
+def test_variable_lookup_type_error():
+    def func(f: f32):
+        for i in seq(0, global_str):
+            f += 1
+
+    with pytest.raises(ParseError, match="type <class 'str'>"):
+        to_uast(func)
+
+    local_str = "xyzzy"
+
+    def func(f: f32):
+        for i in seq(0, local_str):
+            f += 1
+
+    with pytest.raises(ParseError, match="type <class 'str'>"):
+        to_uast(func)
+
+
+def test_variable_lookup_name_error():
+    def func(f: f32):
+        for i in seq(0, xyzzy):
+            f += 1
+
+    with pytest.raises(ParseError, match="'xyzzy' undefined"):
+        to_uast(func)


### PR DESCRIPTION
Previously, when parse_expr failed to resolve a name to a value, it always reported "undefined variable" errors regardless of whether the cause was due to failing to look up the name in the global/local scope, or due to correctly looking up the name but the value not being a valid type (e.g. the name resolving to a str value). I changed the parser to distinguish these 2 cases in the error message (see the new tests I added to see what I mean).