### PR TITLE
Bump Clang 13 to 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Clang 15 (macOS)
         if: runner.os == 'macOS'
-        run: brew install llvm@13
+        run: brew install llvm@15
 
       - name: Run tox
         run: tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
         runner: [ ubuntu-latest, macos-14 ]
         include:
           - runner: ubuntu-latest
-            CC: clang-13
-            CXX: clang++-13
-            CLANG: clang-13
+            CC: clang-15
+            CXX: clang++-15
+            CLANG: clang-15
           - runner: macos-14
             CC: clang # This will be system AppleClang
             CXX: clang++ # This will be system AppleClang
@@ -46,14 +46,14 @@ jobs:
         if: runner.os != 'macOS'
         uses: petarpetrovt/setup-sde@v2.3
 
-      - name: Install Clang 13 (Linux)
+      - name: Install Clang 15 (Linux)
         if: runner.os == 'Linux'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 13
+          sudo ./llvm.sh 15
 
-      - name: Install Clang 13 (macOS)
+      - name: Install Clang 15 (macOS)
         if: runner.os == 'macOS'
         run: brew install llvm@13
 

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -7,8 +7,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 
 ## Compiler configuration
 
-: "${CC:=clang-13}"
-: "${CXX:=clang++-13}"
+: "${CC:=clang-15}"
+: "${CXX:=clang++-15}"
 : "${CFLAGS:=-march=native}"
 : "${CXXFLAGS:=$CFLAGS}"
 : "${CMAKE_BUILD_TYPE:=Release}"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 black==24.10.0
-coverage==7.6.4
+coverage==7.6.10
 pre-commit==4.0.1
 pytest-cov==6.0.0
 pytest-xdist==3.6.1
-pytest==8.3.3
+pytest==8.3.4
 tox==4.23.2
-numpy==2.1.2
+numpy==2.2.1
 Pillow==11.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ PySMT==0.9.6
 asdl-adt==0.1.0
 asdl==0.1.5
 build==1.2.2.post1
-z3-solver==4.13.3.0
+z3-solver==4.13.4.0
 yapf==0.43.0

--- a/tests/amx/test_amx_instr.py
+++ b/tests/amx/test_amx_instr.py
@@ -682,7 +682,7 @@ def test_amx_memories_tile_number_limit(compiler, sde64):
     ):
         test_exe = compiler.compile(
             [nine_amx_tiles],
-            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-13")),
+            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
             CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
         )
 
@@ -812,7 +812,7 @@ def test_amx_memories_tile_size_limit(compiler, sde64):
     with pytest.raises(MemGenError, match="Number of tile rows must"):
         test_exe = compiler.compile(
             [too_many_rows],
-            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-13")),
+            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
             CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
         )
     AMX_TILE.reset_allocations()
@@ -821,7 +821,7 @@ def test_amx_memories_tile_size_limit(compiler, sde64):
         with pytest.raises(MemGenError, match="Number of bytes per row"):
             test_exe = compiler.compile(
                 [bad_byte_proc],
-                CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-13")),
+                CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
                 CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
             )
         AMX_TILE.reset_allocations()
@@ -839,7 +839,7 @@ def test_static_memory_register_allocation(compiler, sde64):
 
     test_exe = compiler.compile(
         [proc_inner],
-        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-13")),
+        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
         CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
     )
     with pytest.raises(
@@ -847,7 +847,7 @@ def test_static_memory_register_allocation(compiler, sde64):
     ):
         test_exe = compiler.compile(
             [proc_outer],
-            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-13")),
+            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
             CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
         )
     AMX_TILE.reset_allocations()
@@ -857,7 +857,7 @@ def _run_amx(compiler, sde64, procs, test_source):
     test_exe = compiler.compile(
         procs,
         test_files={"main.c": str(test_source)},
-        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-13")),
+        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
         CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
     )
 


### PR DESCRIPTION
LLVM 13 is no longer supported. Update workflow scripts to use Clang 15. Bump other dependencies as well.