### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
         runner: [ ubuntu-latest, macos-14 ]
         include:
           - runner: ubuntu-latest
-            CC: clang-15
-            CXX: clang++-15
-            CLANG: clang-15
+            CC: clang-17
+            CXX: clang++-17
+            CLANG: clang-17
           - runner: macos-14
             CC: clang # This will be system AppleClang
             CXX: clang++ # This will be system AppleClang
@@ -46,16 +46,16 @@ jobs:
         if: runner.os != 'macOS'
         uses: petarpetrovt/setup-sde@v2.3
 
-      - name: Install Clang 15 (Linux)
+      - name: Install Clang 17 (Linux)
         if: runner.os == 'Linux'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 15
+          sudo ./llvm.sh 17
 
-      - name: Install Clang 15 (macOS)
+      - name: Install Clang 17 (macOS)
         if: runner.os == 'macOS'
-        run: brew install llvm@15
+        run: brew install llvm@17
 
       - name: Run tox
         run: tox

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -7,8 +7,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 
 ## Compiler configuration
 
-: "${CC:=clang-15}"
-: "${CXX:=clang++-15}"
+: "${CC:=clang-17}"
+: "${CXX:=clang++-17}"
 : "${CFLAGS:=-march=native}"
 : "${CXXFLAGS:=$CFLAGS}"
 : "${CMAKE_BUILD_TYPE:=Release}"

--- a/tests/amx/test_amx_instr.py
+++ b/tests/amx/test_amx_instr.py
@@ -682,7 +682,7 @@ def test_amx_memories_tile_number_limit(compiler, sde64):
     ):
         test_exe = compiler.compile(
             [nine_amx_tiles],
-            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
+            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-17")),
             CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
         )
 
@@ -812,7 +812,7 @@ def test_amx_memories_tile_size_limit(compiler, sde64):
     with pytest.raises(MemGenError, match="Number of tile rows must"):
         test_exe = compiler.compile(
             [too_many_rows],
-            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
+            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-17")),
             CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
         )
     AMX_TILE.reset_allocations()
@@ -821,7 +821,7 @@ def test_amx_memories_tile_size_limit(compiler, sde64):
         with pytest.raises(MemGenError, match="Number of bytes per row"):
             test_exe = compiler.compile(
                 [bad_byte_proc],
-                CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
+                CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-17")),
                 CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
             )
         AMX_TILE.reset_allocations()
@@ -839,7 +839,7 @@ def test_static_memory_register_allocation(compiler, sde64):
 
     test_exe = compiler.compile(
         [proc_inner],
-        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
+        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-17")),
         CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
     )
     with pytest.raises(
@@ -847,7 +847,7 @@ def test_static_memory_register_allocation(compiler, sde64):
     ):
         test_exe = compiler.compile(
             [proc_outer],
-            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
+            CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-17")),
             CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
         )
     AMX_TILE.reset_allocations()
@@ -857,7 +857,7 @@ def _run_amx(compiler, sde64, procs, test_source):
     test_exe = compiler.compile(
         procs,
         test_files={"main.c": str(test_source)},
-        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-15")),
+        CMAKE_C_COMPILER=os.getenv("CLANG", os.getenv("CC", "clang-17")),
         CMAKE_C_FLAGS="-mamx-int8 -mamx-tile",
     )
 


### PR DESCRIPTION
- Bump clang version again to 17
- Fix the failing BLAS CI by explicitly installing OpenBLAS