### PR TITLE
WIP: Partial window of window support (second-order window)

### DIFF
--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -4716,3 +4716,27 @@ def test_old_lift_alloc_config(golden):
 
     bar = autolift_alloc(bar, "tmp_a : _", keep_dims=True)
     assert str(bar) == golden
+
+
+def test_fission_window1():
+    @proc
+    def foo(t: f32[3]):
+        tw = t[:]
+        x: f32[3]
+        for i in seq(0, 2):
+            t[i] = 1.0
+            x[i] = tw[i + 1]
+
+    with pytest.raises(SchedulingError, match="Cannot fission loop"):
+        fission(foo, foo.find("t[_] = 1.0").after())
+
+
+def test_reorder_stmts_window1():
+    @proc
+    def foo(t: f32[3]):
+        tw = t[:]
+        t[0] = 1.0
+        tw[0] = 3.0
+
+    with pytest.raises(SchedulingError, match="do not commute"):
+        reorder_stmts(foo, foo.find("t[_] = 1.0").expand(0, 1))


### PR DESCRIPTION
This is not a complete implementation. Full support would require changing scheduling operators to recognize windows as tensors (e.g. as a source for stage_mem) and/or also have to avoid creating invalid T.Window types or AttributeError-ing due to treating a T.Window as if it were a T.Tensor.

The key helper function is `LoopIR.create_window_type` which takes care of "inlining" the indexing effects of two windows together.

Fixes https://github.com/exo-lang/exo/issues/594