### PR TITLE
fix typo in tutorial

### DIFF
--- a/examples/avx2_matmul/README.md
+++ b/examples/avx2_matmul/README.md
@@ -12,7 +12,7 @@ The complete code with scheduling operations can be found in `exo/examples/avx2_
 
 To start off, let's implement a basic matrix multiplication kernel in Exo object code:
 ```py
-from __future__ import annotation
+from __future__ import annotations
 from exo import *
 
 @proc


### PR DESCRIPTION
Hey Exo team,

Thanks for sharing this very cool project! I just started playing with Exo after the Stanford Software Lunch talk, and I noticed a typo in the tutorial preventing the code from being run as shown. `from __future__ import annotations` was misspelled as `from __future__ import annotation` (singular). The rest of the AVX2 matmul kernel looks fine as written, so it's just this one tiny error.