### PR TITLE
Add Arm SVE instructions support

### DIFF
--- a/examples/avx2_matmul/README.md
+++ b/examples/avx2_matmul/README.md
@@ -264,4 +264,4 @@ This will print out the results of running kernel with and without the AVX instr
 Congratulations on completing this example!
 You might have felt that the scheduling operations in this example were very low-level and could be laborious to write.
 We felt the same! We implemented a new feature called Cursors that provides scheduling automation *external* to the compiler implementation.
-To learn more, please take a look at the [cursors example](cursors/README.md) and our [ASPLOS '25](https://arxiv.org/abs/2411.07211) paper.
+To learn more, please take a look at the [cursors example](../cursors/README.md) and our [ASPLOS '25](https://arxiv.org/abs/2411.07211) paper.

--- a/src/exo/libs/exo_arm_sve.h
+++ b/src/exo/libs/exo_arm_sve.h
@@ -1,0 +1,28 @@
+#ifndef EXO_ARM_SVE_H
+#define EXO_ARM_SVE_H
+
+#include <arm_sve.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline __attribute__((always_inline)) void
+svmla_n_f32_x_vla(int64_t N, float32_t *dst, const float32_t *src1,
+                  float32_t src2) {
+  int64_t i = 0;
+  svbool_t pg = svwhilelt_b32(i, N);
+  do {
+    svst1_f32(pg, &dst[i],
+              svmla_n_f32_x(pg, svld1_f32(pg, &dst[i]), svld1_f32(pg, &src1[i]),
+                            src2));
+    i += svcntw();
+    pg = svwhilelt_b32(i, N);
+  } while (svptest_first(svptrue_b32(), pg));
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/exo/platforms/sve_vla.py
+++ b/src/exo/platforms/sve_vla.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from exo import DRAM, instr
+
+
+@instr(
+    "svmla_n_f32_x_vla({N_data}, &{dst_data}, &{src1_data}, *{src2_data});",
+    c_global='#include "exo_arm_sve.h"',
+)
+def svmla_n_f32_x_vla(
+    N: size,
+    dst: [f32][N] @ DRAM,
+    src1: [f32][N] @ DRAM,
+    src2: f32,
+):
+    assert stride(src1, 0) == 1
+    assert stride(dst, 0) == 1
+
+    for i in seq(0, N):
+        dst[i] += src1[i] * src2

--- a/src/exo/platforms/sve_vls.py
+++ b/src/exo/platforms/sve_vls.py
@@ -22,11 +22,8 @@ def _sve_vector_init(sve_vector_bits):
         @classmethod
         def global_(cls):
             return f"""#include <arm_sve.h>
-#ifdef __FUJITSU
-typedef svfloat32_t svfloat32_vls_t;
-#else
 typedef svfloat32_t svfloat32_vls_t __attribute__((arm_sve_vector_bits({sve_vector_bits})));
-#endif"""
+typedef svfloat64_t svfloat64_vls_t __attribute__((arm_sve_vector_bits({sve_vector_bits})));"""
 
         @classmethod
         def alloc(cls, new_name, prim_type, shape, srcinfo):

--- a/src/exo/platforms/sve_vls.py
+++ b/src/exo/platforms/sve_vls.py
@@ -78,15 +78,14 @@ class SVE_VLS:
 
         @instr("{dst_data} = svld1_f32(svptrue_b32(), &{src_data});")
         def svld1_f32(
-            N: size,
-            dst: [f32][N] @ self.Vector,
-            src: [f32][N] @ DRAM,
+            dst: [f32][float_width] @ self.Vector,
+            src: [f32][float_width] @ DRAM,
         ):
             assert stride(src, 0) == 1
             assert stride(dst, 0) == 1
             assert N == 10
 
-            for i in seq(0, N):
+            for i in seq(0, float_width):
                 dst[i] = src[i]
 
         self.svld1_f32 = svld1_f32

--- a/src/exo/platforms/sve_vls.py
+++ b/src/exo/platforms/sve_vls.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from exo import DRAM, Memory, instr
+from exo.core.memory import MemGenError
+
+
+def _is_const_size(sz, c):
+    return sz.isdecimal() and int(sz) == c
+
+
+def _sve_vector_init(sve_vector_bits):
+    assert sve_vector_bits >= 128
+    assert sve_vector_bits <= 2048
+    assert sve_vector_bits % 128 == 0
+
+    vec_types = {
+        "float": (sve_vector_bits // 32, "svfloat32_vls_t"),
+        "double": (sve_vector_bits // 64, "svfloat64_vls_t"),
+    }
+
+    class SVE_VLS(Memory):
+        @classmethod
+        def global_(cls):
+            return f"""#include <arm_sve.h>
+#ifdef __FUJITSU
+typedef svfloat32_t svfloat32_vls_t;
+#else
+typedef svfloat32_t svfloat32_vls_t __attribute__((arm_sve_vector_bits({sve_vector_bits})));
+#endif"""
+
+        @classmethod
+        def alloc(cls, new_name, prim_type, shape, srcinfo):
+            if not shape:
+                raise MemGenError(f"{srcinfo}: AVX2 vectors are not scalar values")
+
+            if prim_type not in vec_types.keys():
+                raise MemGenError(
+                    f"{srcinfo}: AVX2 vectors must be f32/f64/ui16 (for now), got {prim_type}"
+                )
+
+            reg_width, C_reg_type_name = vec_types[prim_type]
+            if not _is_const_size(shape[-1], reg_width):
+                raise MemGenError(
+                    f"{srcinfo}: AVX2 vectors of type {prim_type} must be {reg_width}-wide, got {shape}"
+                )
+            shape = shape[:-1]
+            if shape:
+                result = f"{C_reg_type_name} {new_name}[{']['.join(map(str, shape))}];"
+            else:
+                result = f"{C_reg_type_name} {new_name};"
+            return result
+
+        @classmethod
+        def can_read(cls):
+            return False
+
+        @classmethod
+        def free(cls, new_name, prim_type, shape, srcinfo):
+            return ""
+
+        @classmethod
+        def window(cls, basetyp, baseptr, indices, strides, srcinfo):
+            assert strides[-1] == "1"
+            idxs = indices[:-1] or ""
+            if idxs:
+                idxs = "[" + "][".join(idxs) + "]"
+            return f"{baseptr}{idxs}"
+
+    return SVE_VLS, vec_types
+
+
+class SVE_VLS:
+    def __init__(self, sve_vector_bits):
+        self.Vector, vec_types = _sve_vector_init(sve_vector_bits)
+
+        float_width, _ = vec_types["float"]
+        double_width, _ = vec_types["double"]
+
+        @instr("{dst_data} = svld1_f32(svptrue_b32(), &{src_data});")
+        def svld1_f32(
+            N: size,
+            dst: [f32][N] @ self.Vector,
+            src: [f32][N] @ DRAM,
+        ):
+            assert stride(src, 0) == 1
+            assert stride(dst, 0) == 1
+            assert N == 10
+
+            for i in seq(0, N):
+                dst[i] = src[i]
+
+        self.svld1_f32 = svld1_f32
+
+        @instr("svst1_f32(svptrue_b32(), &{dst_data}, {src_data});")
+        def svst1_f32(
+            dst: [f32][float_width] @ DRAM,
+            src: [f32][float_width] @ self.Vector,
+        ):
+            assert stride(src, 0) == 1
+            assert stride(dst, 0) == 1
+
+            for i in seq(0, float_width):
+                dst[i] = src[i]
+
+        self.svst1_f32 = svst1_f32
+
+        @instr(
+            "{dst_data} = svmla_n_f32_x(svptrue_b32(), {dst_data}, {src1_data}, *{src2_data});"
+        )
+        def svmla_n_f32_x(
+            dst: [f32][float_width] @ self.Vector,
+            src1: [f32][float_width] @ self.Vector,
+            src2: f32,
+        ):
+            assert stride(src1, 0) == 1
+            assert stride(dst, 0) == 1
+
+            for i in seq(0, float_width):
+                dst[i] += src1[i] * src2
+
+        self.svmla_n_f32_x = svmla_n_f32_x

--- a/src/exo/platforms/sve_vls.py
+++ b/src/exo/platforms/sve_vls.py
@@ -83,7 +83,6 @@ class SVE_VLS:
         ):
             assert stride(src, 0) == 1
             assert stride(dst, 0) == 1
-            assert N == 10
 
             for i in seq(0, float_width):
                 dst[i] = src[i]

--- a/tests/golden/test_sve_vla/test_compile_sve_vla_svmla.txt
+++ b/tests/golden/test_sve_vla/test_compile_sve_vla_svmla.txt
@@ -1,0 +1,21 @@
+#include "test.h"
+
+#include "exo_arm_sve.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+// svmla(
+//     N : size,
+//     C : f32[N] @DRAM,
+//     A : f32[N] @DRAM,
+//     B : f32 @DRAM
+// )
+void svmla( void *ctxt, int_fast32_t N, float* C, const float* A, const float* B ) {
+svmla_n_f32_x_vla((N), &C[0], &A[0], *(B));
+}
+
+
+/* relying on the following instruction..."
+svmla_n_f32_x_vla(N,dst,src1,src2)
+svmla_n_f32_x_vla({N_data}, &{dst_data}, &{src1_data}, *{src2_data});
+*/

--- a/tests/golden/test_sve_vla/test_gen_sve_vla_svmla.txt
+++ b/tests/golden/test_sve_vla/test_gen_sve_vla_svmla.txt
@@ -1,0 +1,2 @@
+def svmla(N: size, C: f32[N] @ DRAM, A: f32[N] @ DRAM, B: f32 @ DRAM):
+    svmla_n_f32_x_vla(N, C[0:N], A[0:N], B)

--- a/tests/golden/test_sve_vls/test_compile_sve_vls_svmla.txt
+++ b/tests/golden/test_sve_vls/test_compile_sve_vls_svmla.txt
@@ -1,0 +1,37 @@
+#include "test.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <arm_sve.h>
+typedef svfloat32_t svfloat32_vls_t __attribute__((arm_sve_vector_bits(512)));
+typedef svfloat64_t svfloat64_vls_t __attribute__((arm_sve_vector_bits(512)));
+
+/* relying on the following instruction..."
+svld1_f32(dst,src)
+{dst_data} = svld1_f32(svptrue_b32(), &{src_data});
+*/
+// svmla(
+//     C : f32[16] @DRAM,
+//     A : f32[16] @DRAM,
+//     B : f32 @DRAM
+// )
+void svmla( void *ctxt, float* C, const float* A, const float* B ) {
+svfloat32_vls_t C_reg;
+C_reg = svld1_f32(svptrue_b32(), &C[0]);
+svfloat32_vls_t A_reg;
+A_reg = svld1_f32(svptrue_b32(), &A[0]);
+C_reg = svmla_n_f32_x(svptrue_b32(), C_reg, A_reg, *(B));
+svst1_f32(svptrue_b32(), &C[0], C_reg);
+}
+
+
+/* relying on the following instruction..."
+svmla_n_f32_x(dst,src1,src2)
+{dst_data} = svmla_n_f32_x(svptrue_b32(), {dst_data}, {src1_data}, *{src2_data});
+*/
+
+/* relying on the following instruction..."
+svst1_f32(dst,src)
+svst1_f32(svptrue_b32(), &{dst_data}, {src_data});
+*/

--- a/tests/golden/test_sve_vls/test_gen_sve_vls_svmla.txt
+++ b/tests/golden/test_sve_vls/test_gen_sve_vls_svmla.txt
@@ -1,0 +1,10 @@
+def svmla(N: size, C: f32[N] @ DRAM, A: f32[N] @ DRAM, B: f32 @ DRAM):
+    assert N == 16
+    C_reg: f32[N] @ SVE_VLS
+    svld1_f32(N, C_reg[0:N], C[0:N])
+    A_reg: f32[N] @ SVE_VLS
+    svld1_f32(N, A_reg[0:N], A[0:N])
+    for i in seq(0, N):
+        C_reg[i] += A_reg[i] * B
+    for i0 in seq(0, N):
+        C[i0] = C_reg[i0]

--- a/tests/golden/test_sve_vls/test_gen_sve_vls_svmla.txt
+++ b/tests/golden/test_sve_vls/test_gen_sve_vls_svmla.txt
@@ -1,10 +1,7 @@
-def svmla(N: size, C: f32[N] @ DRAM, A: f32[N] @ DRAM, B: f32 @ DRAM):
-    assert N == 16
-    C_reg: f32[N] @ SVE_VLS
-    svld1_f32(N, C_reg[0:N], C[0:N])
-    A_reg: f32[N] @ SVE_VLS
-    svld1_f32(N, A_reg[0:N], A[0:N])
-    for i in seq(0, N):
-        C_reg[i] += A_reg[i] * B
-    for i0 in seq(0, N):
-        C[i0] = C_reg[i0]
+def svmla(C: f32[16] @ DRAM, A: f32[16] @ DRAM, B: f32 @ DRAM):
+    C_reg: f32[16] @ SVE_VLS
+    svld1_f32(C_reg[0:16], C[0:16])
+    A_reg: f32[16] @ SVE_VLS
+    svld1_f32(A_reg[0:16], A[0:16])
+    svmla_n_f32_x(C_reg[0:16], A_reg[0:16], B)
+    svst1_f32(C[0:16], C_reg[0:16])

--- a/tests/test_sve_vla.py
+++ b/tests/test_sve_vla.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from exo import proc
+from exo import proc, compile_procs_to_strings
 from exo.platforms.sve_vla import *
 from exo.stdlib.scheduling import *
 
@@ -30,3 +30,9 @@ def test_sve_vla_svmla():
 
 def test_gen_sve_vla_svmla(golden, test_sve_vla_svmla):
     assert str(test_sve_vla_svmla) == golden
+
+
+def test_compile_sve_vla_svmla(golden, test_sve_vla_svmla):
+    c_file, _ = compile_procs_to_strings([test_sve_vla_svmla], "test.h")
+
+    assert c_file == golden

--- a/tests/test_sve_vla.py
+++ b/tests/test_sve_vla.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from exo import proc
+from exo.platforms.sve_vla import *
+from exo.stdlib.scheduling import *
+
+
+@pytest.fixture
+def test_sve_vla_svmla():
+    @proc
+    def svmla(
+        N: size,
+        C: f32[N] @ DRAM,
+        A: f32[N] @ DRAM,
+        B: f32,
+    ):
+        for i in seq(0, N):
+            C[i] += A[i] * B
+
+    def simple_svmla(p=svmla):
+        p = replace_all(p, svmla_n_f32_x_vla)
+        return p
+
+    simple_sve_vla_svmla = simple_svmla()
+
+    return simplify(simple_sve_vla_svmla)
+
+
+@pytest.mark.isa("sve_vla")
+def test_gen_sve_vla_svmla(golden, test_sve_vla_svmla):
+    assert str(test_sve_vla_svmla) == golden

--- a/tests/test_sve_vla.py
+++ b/tests/test_sve_vla.py
@@ -28,6 +28,5 @@ def test_sve_vla_svmla():
     return simplify(simple_sve_vla_svmla)
 
 
-@pytest.mark.isa("sve_vla")
 def test_gen_sve_vla_svmla(golden, test_sve_vla_svmla):
     assert str(test_sve_vla_svmla) == golden

--- a/tests/test_sve_vls.py
+++ b/tests/test_sve_vls.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from exo import proc
+from exo.platforms.sve_vls import *
+from exo.stdlib.scheduling import *
+
+SVE_VLS = SVE_VLS(512)
+
+
+@pytest.fixture
+def test_sve_vls_svmla():
+    @proc
+    def svmla(
+        N: size,
+        C: f32[N] @ DRAM,
+        A: f32[N] @ DRAM,
+        B: f32,
+    ):
+        assert N == 16
+        for i in seq(0, N):
+            C[i] += A[i] * B
+
+    def simple_svmla(p=svmla):
+        p = stage_mem(p, "for i in _:_", "C[0:N]", "C_reg")
+        p = set_memory(p, "C_reg:_", SVE_VLS.Vector)
+        p = stage_mem(p, "for i in _:_", "A[0:N]", "A_reg")
+        p = set_memory(p, "A_reg:_", SVE_VLS.Vector)
+        p = replace_all(p, SVE_VLS.svld1_f32)
+        p = replace_all(p, SVE_VLS.svst1_f32)
+        p = replace_all(p, SVE_VLS.svmla_n_f32_x)
+        return p
+
+    simple_sve_vls_svmla = simple_svmla()
+
+    return simplify(simple_sve_vls_svmla)
+
+
+@pytest.mark.isa("sve_vls")
+def test_gen_sve_vls_svmla(golden, test_sve_vls_svmla):
+    assert str(test_sve_vls_svmla) == golden

--- a/tests/test_sve_vls.py
+++ b/tests/test_sve_vls.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from exo import proc
+from exo import proc, compile_procs_to_strings
 from exo.platforms.sve_vls import *
 from exo.stdlib.scheduling import *
 
@@ -37,3 +37,9 @@ def test_sve_vls_svmla():
 
 def test_gen_sve_vls_svmla(golden, test_sve_vls_svmla):
     assert str(test_sve_vls_svmla) == golden
+
+
+def test_compile_sve_vls_svmla(golden, test_sve_vls_svmla):
+    c_file, _ = compile_procs_to_strings([test_sve_vls_svmla], "test.h")
+
+    assert c_file == golden


### PR DESCRIPTION
# Overview

Add support for Arm SVE instructions to the Exo language.

# Arm SVE Instructions

A SIMD instructions with registers of variable bit widths depending on the implementation. 

Two vectorization approaches are available:

- Vector Length Specific (VLS, traditional SIMD)
- Vector Length Agnostic (VLA, can be applied to variable length vectors)

# platforms/sve_vls.py

This file implements the VLS approach. 

`Memory` class and `@instr` function require knowledge of the target processor's register bit width before the Exo parser operates. By wrapping them in `SVE_VLS` class, their initialization and the operation of the parser is deferred.

Example:

```py
SVE_VLS = SVE_VLS(512)

# ...

vls = set_memory(vls, "SVE_reg:_", SVE_VLS.Vector)
vls = replace_all(vls, SVE_VLS.svld1_f32)
```

# platforms/sve_vla.py

This file implements the VLA approach.

`@instr` functions don't require knowledge of the target processor's register bit width.

Example:

```py
vla = replace_all(vla, svmla_n_f32_x_vla)
```

To use the output generated by Exo compilation, `libs/exo_arm_sve.h` is required.
