### PR TITLE
Fix a bug that caused false type errors for externs

### DIFF
--- a/src/exo/backend/prec_analysis.py
+++ b/src/exo/backend/prec_analysis.py
@@ -200,24 +200,23 @@ class PrecisionAnalysis(LoopIR_Rewrite):
             return LoopIR.BinOp(e.op, lhs, rhs, typ, e.srcinfo)
 
         elif isinstance(e, LoopIR.Extern):
+            new_args = [self.apply_e(a) for a in e.args]
+
             typ = T.R
-            for a in e.args:
+            for a in new_args:
                 if a.type != T.R:
                     typ = a.type
 
-            new_args = []
-            for a in e.args:
-                a = self.apply_e(a)
+            for i, a in enumerate(new_args):
                 if typ != a.type:
                     # coerce if const and real
                     if a.type == T.R:
-                        a = self.coerce_e(a, typ)
+                        new_args[i] = self.coerce_e(a, typ)
                     else:
                         self.err(
                             e,
                             f"all extern arguments must have a same type, got {typ} and {a.type}",
                         )
-                new_args.append(a)
 
             return LoopIR.Extern(e.f, new_args, typ, e.srcinfo)
 


### PR DESCRIPTION
Hi,

I've used Exo in some experiments and encountered an issue with precision analysis when using `LoopIR.Extern`.

The issue happens at src/exo/backend/prec_analysis.py:202-222 when none of the arguments in `e.args` have a resolved type without passing them through `self.apply_e`. This leads to `typ == T.R` at the beginning of the next loop (starting at 209), which breaks its logic.

This pull request seems to be the most conservative resolution of the issue - it simply reorders passing the arguments through `self.apply_e` before computing the shared `typ`.

The change doesn't break any tests in `pytest`.