### PR TITLE
Fix frame.f_locals usage for PEP 667 (Python 3.13+)

### DIFF
--- a/src/exo/frontend/parse_fragment.py
+++ b/src/exo/frontend/parse_fragment.py
@@ -25,7 +25,7 @@ def parse_fragment(
     stack_frames: [inspect.FrameInfo] = inspect.stack()
     # get source location where this is getting called from
     caller = inspect.getframeinfo(stack_frames[call_depth][0])
-    func_locals = ChainMap(stack_frames[call_depth].frame.f_locals)
+    func_locals = ChainMap(dict(stack_frames[call_depth].frame.f_locals))
     func_globals = ChainMap(stack_frames[call_depth].frame.f_globals)
 
     # parse the pattern we're going to use to match

--- a/src/exo/frontend/pattern_match.py
+++ b/src/exo/frontend/pattern_match.py
@@ -82,7 +82,7 @@ def match_pattern(
     stack_frames: [inspect.FrameInfo] = inspect.stack()
     # get source location where this is getting called from
     caller = inspect.getframeinfo(stack_frames[call_depth][0])
-    func_locals = ChainMap(stack_frames[call_depth].frame.f_locals)
+    func_locals = ChainMap(dict(stack_frames[call_depth].frame.f_locals))
     func_globals = stack_frames[call_depth].frame.f_globals
 
     # parse the pattern we're going to use to match

--- a/src/exo/frontend/pyparser.py
+++ b/src/exo/frontend/pyparser.py
@@ -123,12 +123,9 @@ class FrameScope:
         not possible to add new local variables or modify the local variables by modifying
         the returned dictionary.
         """
+        f_locals = dict(self.frame.f_locals)
         return {
-            var: (
-                BoundLocal(self.frame.f_locals[var])
-                if var in self.frame.f_locals
-                else None
-            )
+            var: (BoundLocal(f_locals[var]) if var in f_locals else None)
             for var in self.frame.f_code.co_varnames
             + self.frame.f_code.co_cellvars
             + self.frame.f_code.co_freevars


### PR DESCRIPTION
[PEP 667](https://peps.python.org/pep-0667/) (Python 3.13+): `frame.f_locals` returns a `FrameLocalsProxy`, not a `dict`. Snapshot via `dict(...)` at the three scope-capture sites.

Adapted from https://github.com/sueszli/exojit/blob/main/exojit/patches_exo.py.

(Happy to migrate the 3 other patches as well!)