### PR TITLE
Fix lint workflow checkout for fork PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Format C files
       - uses: DoozyX/clang-format-lint-action@v0.13


### PR DESCRIPTION
`Lint` runs on `pull_request_target` but `actions/checkout@v4` only sets `ref:`, so it defaults to `exo-lang/exo` and can't find the fork's branch. Every external fork PR fails (see #835).

Set `repository: head.repo.full_name` and pin to `head.sha`.

Safe: the lint steps only read files, no repo code runs.