### PR TITLE
Cap z3-solver below 4.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "PySMT>=0.9.6",
     "asdl-adt>=0.1,<0.2",
     "yapf>=0.43",
-    "z3-solver>=4.15",
+    "z3-solver>=4.15,<4.15.5",
 ]
 
 ##


### PR DESCRIPTION
z3-solver 4.15.5+ dropped the macos-14 wheel, so CI built it from source and failed. Pin `<4.15.5`.

Fixes #835 CI.